### PR TITLE
fix: removing uuid from id definitions and test

### DIFF
--- a/across/client/apis/filter.py
+++ b/across/client/apis/filter.py
@@ -1,5 +1,3 @@
-from uuid import UUID
-
 import across.sdk.v1 as sdk
 from across.sdk.v1.api_client_wrapper import ApiClientWrapper
 
@@ -22,7 +20,7 @@ class Filter:
         """
         self.across_client = across_client
 
-    def get(self, id: UUID) -> sdk.Filter:
+    def get(self, id: str) -> sdk.Filter:
         """
         Retrieve a single Filter by ID.
 
@@ -41,7 +39,7 @@ class Filter:
         name: str | None = None,
         covers_wavelength: float | None = None,
         instrument_name: str | None = None,
-        instrument_id: UUID | None = None,
+        instrument_id: str | None = None,
     ) -> list[sdk.Filter]:
         """
         Retrieve multiple filters filtered by optional criteria.

--- a/across/client/apis/instrument.py
+++ b/across/client/apis/instrument.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from uuid import UUID
 
 import across.sdk.v1 as sdk
 from across.sdk.v1.api_client_wrapper import ApiClientWrapper
@@ -23,7 +22,7 @@ class Instrument:
         """
         self.across_client = across_client
 
-    def get(self, id: UUID) -> sdk.Instrument:
+    def get(self, id: str) -> sdk.Instrument:
         """
         Retrieve a single Instrument by ID.
 
@@ -41,7 +40,7 @@ class Instrument:
         self,
         name: str | None = None,
         telescope_name: str | None = None,
-        telescope_id: UUID | None = None,
+        telescope_id: str | None = None,
         created_on: datetime | None = None,
     ) -> list[sdk.Instrument]:
         """

--- a/across/client/apis/observation.py
+++ b/across/client/apis/observation.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from uuid import UUID
 
 import across.sdk.v1 as sdk
 from across.sdk.v1.api_client_wrapper import ApiClientWrapper
@@ -23,7 +22,7 @@ class Observation:
         """
         self.across_client = across_client
 
-    def get(self, id: UUID) -> sdk.Observation:
+    def get(self, id: str) -> sdk.Observation:
         """
         Retrieve a single Observation by ID.
 
@@ -42,10 +41,10 @@ class Observation:
         page: int | None = None,
         page_limit: int | None = None,
         external_id: str | None = None,
-        schedule_ids: list[UUID | None] | None = None,
-        observatory_ids: list[UUID] | None = None,
-        telescope_ids: list[UUID] | None = None,
-        instrument_ids: list[UUID] | None = None,
+        schedule_ids: list[str | None] | None = None,
+        observatory_ids: list[str] | None = None,
+        telescope_ids: list[str] | None = None,
+        instrument_ids: list[str] | None = None,
         status: sdk.ObservationStatus | None = None,
         proposal: str | None = None,
         object_name: str | None = None,
@@ -71,13 +70,13 @@ class Observation:
                 Filter by number of records per page
             external_id (str | None):
                 Filter by an external identifier.
-            schedule_ids (list[UUID | None] | None):
+            schedule_ids (list[str | None] | None):
                 Filter by one or more schedule IDs.
-            observatory_ids (list[UUID] | None):
+            observatory_ids (list[str] | None):
                 Filter by one or more observatory IDs.
-            telescope_ids (list[UUID] | None):
+            telescope_ids (list[str] | None):
                 Filter by one or more telescope IDs.
-            instrument_ids (list[UUID] | None):
+            instrument_ids (list[str] | None):
                 Filter by one or more instrument IDs.
             status (sdk.ObservationStatus | None):
                 Filter by observation status.

--- a/across/client/apis/observatory.py
+++ b/across/client/apis/observatory.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from uuid import UUID
 
 import across.sdk.v1 as sdk
 from across.sdk.v1.api_client_wrapper import ApiClientWrapper
@@ -24,12 +23,12 @@ class Observatory:
         """
         self.across_client = across_client
 
-    def get(self, id: UUID) -> sdk.Observatory:
+    def get(self, id: str) -> sdk.Observatory:
         """
         Retrieve a single Observatory by ID.
 
         Args:
-            id (UUID):
+            id (str):
                 The unique identifier of the observatory to retrieve.
 
         Returns:
@@ -43,7 +42,7 @@ class Observatory:
         name: str | None = None,
         type: sdk.ObservatoryType | None = None,
         telescope_name: str | None = None,
-        telescope_id: UUID | None = None,
+        telescope_id: str | None = None,
         ephemeris_type: list[sdk.EphemerisType] | None = None,
         created_on: datetime | None = None,
     ) -> list[sdk.Observatory]:
@@ -57,7 +56,7 @@ class Observatory:
                 Filter by observatory type.
             telescope_name (str | None, optional):
                 Filter by telescope name.
-            telescope_id (UUID | None, optional):
+            telescope_id (str | None, optional):
                 Filter by telescope ID.
             ephemeris_type (list[sdk.EphemerisType] | None, optional):
                 Filter by one or more ephemeris types.

--- a/across/client/apis/schedule.py
+++ b/across/client/apis/schedule.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from uuid import UUID
 
 import across.sdk.v1 as sdk
 from across.sdk.v1.api_client_wrapper import ApiClientWrapper
@@ -23,7 +22,7 @@ class Schedule:
         """
         self.across_client = across_client
 
-    def get(self, id: UUID) -> sdk.Schedule:
+    def get(self, id: str) -> sdk.Schedule:
         """
         Retrieve a single Schedule by ID.
 
@@ -47,9 +46,9 @@ class Schedule:
         external_id: str | None = None,
         fidelity: sdk.ScheduleFidelity | None = None,
         created_on: datetime | None = None,
-        observatory_ids: list[UUID | None] | None = None,
+        observatory_ids: list[str | None] | None = None,
         observatory_names: list[str | None] | None = None,
-        telescope_ids: list[UUID | None] | None = None,
+        telescope_ids: list[str | None] | None = None,
         telescope_names: list[str | None] | None = None,
         name: str | None = None,
     ) -> sdk.PageSchedule:
@@ -75,13 +74,13 @@ class Schedule:
                 Filter by schedule fidelity level.
             created_on (datetime | None, optional):
                 Filter by creation timestamp.
-            observatory_ids (list[UUID | None] | None, optional):
+            observatory_ids (list[str | None] | None, optional):
                 Filter by one or more observatory IDs.
-            observatory_names (list[UUID | None] | None, optional):
+            observatory_names (list[str | None] | None, optional):
                 Filter by one or more observatory names.
-            telescope_ids (list[UUID | None] | None, optional):
+            telescope_ids (list[str | None] | None, optional):
                 Filter by one or more telescope IDs.
-            telescope_names (list[UUID | None] | None, optional):
+            telescope_names (list[str | None] | None, optional):
                 Filter by one or more telescope names.
             name (str | None, optional):
                 Filter by schedule name.
@@ -116,9 +115,9 @@ class Schedule:
         external_id: str | None = None,
         fidelity: sdk.ScheduleFidelity | None = None,
         created_on: datetime | None = None,
-        observatory_ids: list[UUID | None] | None = None,
+        observatory_ids: list[str | None] | None = None,
         observatory_names: list[str | None] | None = None,
-        telescope_ids: list[UUID | None] | None = None,
+        telescope_ids: list[str | None] | None = None,
         telescope_names: list[str | None] | None = None,
         name: str | None = None,
     ) -> sdk.PageSchedule:
@@ -142,11 +141,11 @@ class Schedule:
                 Filter by schedule fidelity level.
             created_on (datetime | None, optional):
                 Filter by creation timestamp.
-            observatory_ids (list[UUID | None] | None, optional):
+            observatory_ids (list[str | None] | None, optional):
                 Filter by one or more observatory IDs.
             observatory_names (list[str | None] | None, optional):
                 Filter by one or more observatory names.
-            telescope_ids (list[UUID | None] | None, optional):
+            telescope_ids (list[str | None] | None, optional):
                 Filter by one or more telescope IDs.
             telescope_names (list[str | None] | None, optional):
                 Filter by one or more telescope names.
@@ -188,7 +187,7 @@ class Schedule:
                     fidelity: ScheduleFidelity | None,
                     observations: List[ObservationCreate]
         Returns:
-            schedule_id (str | uuid)
+            schedule_id (str | str)
                 model id for the newly created schedule
         """
         return sdk.ScheduleApi(self.across_client).create_schedule(schedule_create=schedule)

--- a/across/client/apis/telescope.py
+++ b/across/client/apis/telescope.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from uuid import UUID
 
 import across.sdk.v1 as sdk
 from across.sdk.v1.api_client_wrapper import ApiClientWrapper
@@ -23,7 +22,7 @@ class Telescope:
         """
         self.across_client = across_client
 
-    def get(self, id: UUID) -> sdk.Telescope:
+    def get(self, id: str) -> sdk.Telescope:
         """
         Retrieve a single Telescope by ID.
 
@@ -41,7 +40,7 @@ class Telescope:
         self,
         name: str | None = None,
         instrument_name: str | None = None,
-        instrument_id: UUID | None = None,
+        instrument_id: str | None = None,
         created_on: datetime | None = None,
     ) -> list[sdk.Telescope]:
         """

--- a/tests/apis/filter/conftest.py
+++ b/tests/apis/filter/conftest.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from unittest.mock import MagicMock
-from uuid import uuid4
 
 import pytest
 
@@ -18,14 +17,14 @@ def fake_filter() -> sdk.Filter:
     tests that require an Filter.
     """
     return sdk.Filter(
-        id=uuid4(),
+        id="filter-uuid",
         created_on=datetime.fromisoformat("2025-07-15T00:00:00"),
         name="Treedome Filter",
         peak_wavelength=6500,
         min_wavelength=6000,
         max_wavelength=7000,
         is_operational=True,
-        instrument_id=uuid4(),
+        instrument_id="instrument-uuid",
         sensitivity_depth=24,
         sensitivity_depth_unit=1,
         sensitivity_time_seconds=600,

--- a/tests/apis/instrument/conftest.py
+++ b/tests/apis/instrument/conftest.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from unittest.mock import MagicMock
-from uuid import uuid4
 
 import pytest
 
@@ -18,21 +17,21 @@ def fake_instrument() -> sdk.Instrument:
     tests that require an Instrument.
     """
     return sdk.Instrument(
-        id=uuid4(),
+        id="instrument-uuid",
         created_on=datetime.fromisoformat("2025-07-15T00:00:00"),
         name="Treedome Instrument",
         short_name="TI",
-        telescope=sdk.IDNameSchema(id=uuid4(), name="Treedome Telescope", short_name="TT"),
+        telescope=sdk.IDNameSchema(id="telescope-uuid", name="Treedome Telescope", short_name="TT"),
         filters=[
             sdk.Filter(
-                id=uuid4(),
+                id="filter-uuid",
                 created_on=datetime.fromisoformat("2025-07-15T00:00:00"),
                 name="Treedome Filter",
                 peak_wavelength=6500,
                 min_wavelength=6000,
                 max_wavelength=7000,
                 is_operational=True,
-                instrument_id=uuid4(),
+                instrument_id="instrument-uuid",
                 sensitivity_depth=24,
                 sensitivity_depth_unit=1,
                 sensitivity_time_seconds=600,

--- a/tests/apis/observation/conftest.py
+++ b/tests/apis/observation/conftest.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from unittest.mock import MagicMock
-from uuid import uuid4
 
 import pytest
 
@@ -18,10 +17,10 @@ def fake_observation() -> sdk.Observation:
     tests that require an observation.
     """
     return sdk.Observation(
-        id=uuid4(),
+        id="observation-uuid",
         created_on=datetime.fromisoformat("2025-07-15T00:00:00"),
-        instrument_id=uuid4(),
-        schedule_id=uuid4(),
+        instrument_id="instrument-uuid",
+        schedule_id="schedule-uuid",
         object_name="super star",
         pointing_position=sdk.Coordinate(ra=42, dec=42),
         object_position=sdk.Coordinate(ra=42, dec=42),

--- a/tests/apis/observatory/conftest.py
+++ b/tests/apis/observatory/conftest.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from unittest.mock import MagicMock
-from uuid import uuid4
 
 import pytest
 
@@ -18,13 +17,14 @@ def fake_observatory() -> sdk.Observatory:
     tests that require an Observatory.
     """
     return sdk.Observatory(
-        id=uuid4(),
+        id="obseervatory-uuid",
         created_on=datetime.fromisoformat("2025-07-15T00:00:00"),
         name="Treedome Space Observatory",
         short_name="MT",
         type=sdk.ObservatoryType.SPACE_BASED,
-        telescopes=[sdk.IDNameSchema(id=uuid4(), name="Treedome Telescope", short_name="tree")],
+        telescopes=[sdk.IDNameSchema(id="telescope-uuid", name="Treedome Telescope", short_name="tree")],
         reference_url="cartoonnetwork.com",
+        operational=None,
         ephemeris_types=[
             sdk.ObservatoryEphemerisType(
                 ephemeris_type=sdk.EphemerisType.TLE,

--- a/tests/apis/schedule/conftest.py
+++ b/tests/apis/schedule/conftest.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from unittest.mock import MagicMock
-from uuid import uuid4
 
 import pytest
 
@@ -18,10 +17,10 @@ def fake_schedule() -> sdk.Schedule:
     tests that require an schedule.
     """
     return sdk.Schedule(
-        id=uuid4(),
+        id="schedule-uuid",
         created_on=datetime.fromisoformat("2025-07-15T00:00:00"),
-        telescope_id=uuid4(),
-        created_by_id=uuid4(),
+        telescope_id="telescope-uuid",
+        created_by_id="created_by-uuid",
         name="Treedome Telescope Schedule",
         date_range=sdk.DateRange(
             begin=datetime.fromisoformat("2025-07-15T00:00:00"),
@@ -33,10 +32,10 @@ def fake_schedule() -> sdk.Schedule:
         observation_count=1,
         observations=[
             sdk.Observation(
-                id=uuid4(),
+                id="observation-uuid",
                 created_on=datetime.fromisoformat("2025-07-15T00:00:00"),
-                instrument_id=uuid4(),
-                schedule_id=uuid4(),
+                instrument_id="instrument-uuid",
+                schedule_id="schedule-uuid",
                 object_name="super star",
                 pointing_position=sdk.Coordinate(ra=42, dec=42),
                 object_position=sdk.Coordinate(ra=42, dec=42),
@@ -85,8 +84,8 @@ def mock_schedule_api(fake_schedule: sdk.Schedule, fake_page_schedule: sdk.PageS
     mock.get_schedules = MagicMock(return_value=fake_page_schedule)
     mock.get_schedules_history = MagicMock(return_value=fake_page_schedule)
     mock.get_schedule = MagicMock(return_value=fake_schedule)
-    mock.create_schedule = MagicMock(return_value=uuid4())
-    mock.create_many_schedules = MagicMock(return_value=[uuid4()])
+    mock.create_schedule = MagicMock(return_value="schedule-uuid")
+    mock.create_many_schedules = MagicMock(return_value=["schedule-uuid"])
     return mock
 
 

--- a/tests/apis/schedule/test_schedule.py
+++ b/tests/apis/schedule/test_schedule.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from unittest.mock import MagicMock
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 import across.sdk.v1 as sdk
 from across.client.apis import Schedule
@@ -89,7 +89,7 @@ class TestPost:
         Posted schedule should return uuid (as str)
         """
         schedule_create = sdk.ScheduleCreate(
-            telescope_id=uuid4(),
+            telescope_id="telescope-uuid",
             name="test schedule",
             date_range=sdk.DateRange(
                 begin=datetime.fromisoformat("2025-07-15T00:00:00"),
@@ -102,7 +102,7 @@ class TestPost:
         )
         schedule = Schedule(across_client=MagicMock())
         result = schedule.post(schedule_create)
-        assert isinstance(result, UUID)
+        assert isinstance(result, str)
 
 
 class TestPostMany:
@@ -115,7 +115,7 @@ class TestPostMany:
         Posted Schedules should return a list of uuids
         """
         schedule_create = sdk.ScheduleCreate(
-            telescope_id=uuid4(),
+            telescope_id="telescope-uuid",
             name="test schedule",
             date_range=sdk.DateRange(
                 begin=datetime.fromisoformat("2025-07-15T00:00:00"),
@@ -127,5 +127,7 @@ class TestPostMany:
             observations=[],
         )
         schedule = Schedule(across_client=MagicMock())
-        result = schedule.post_many(sdk.ScheduleCreateMany(schedules=[schedule_create], telescope_id=uuid4()))
+        result = schedule.post_many(
+            sdk.ScheduleCreateMany(schedules=[schedule_create], telescope_id="telescope-uuid")
+        )
         assert isinstance(result, list)

--- a/tests/apis/telescope/conftest.py
+++ b/tests/apis/telescope/conftest.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from unittest.mock import MagicMock
-from uuid import uuid4
 
 import pytest
 
@@ -18,14 +17,16 @@ def fake_telescope() -> sdk.Telescope:
     tests that require an Telescope.
     """
     return sdk.Telescope(
-        id=uuid4(),
+        id="telescope-uuid",
         created_on=datetime.fromisoformat("2025-07-15T00:00:00"),
         name="Treedome Telescope",
         short_name="TST",
-        observatory=sdk.IDNameSchema(id=uuid4(), name="Treedome Space Observatory", short_name="TST"),
+        observatory=sdk.IDNameSchema(
+            id="observatory-uuid", name="Treedome Space Observatory", short_name="TST"
+        ),
         instruments=[
             sdk.TelescopeInstrument(
-                id=uuid4(),
+                id="instrument-uuid",
                 name="Treedome Instrument",
                 short_name="ti",
                 created_on=datetime.fromisoformat("2025-07-15T00:00:00"),


### PR DESCRIPTION
### Description

This PR fixes the typing errors from the bugs in the smoke tests. All ids were typed as `UUID` but the sdk was changed so that they are `StrictStr`. This PR changes all id types to str.

### Related Issue(s)

https://github.com/ACROSS-Team/across-client/issues/21

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

All functionality is the same, but tests pass with the new sdk changes

### Testing

Tests pass 