### PR TITLE
feat(legal): add NASA copyright notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ nircam = client.instrument.get_many(name="nircam")[0]
 
 nircam_observations = client.observation.get_many(
    instrument_ids=[nircam.id],
-   status="performed", 
+   status="performed",
    date_range_begin=datetime(...),
    date_range_end=datetime(...),
 )
- ```
+```
 
 ## Contributing
 
@@ -57,3 +57,23 @@ Found a bug? Want to make a feature request? Or create a pull request? Navigate 
 ## Other Links
 
 [Open Science at NASA](https://science.nasa.gov/open-science/)
+
+## Notice
+
+NASA Docket No. GSC-19,469-1, and identified as "Astrophysics Cross-Observatory
+Science Support (ACROSS) System
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.“
+
+Copyright © 2025 United States Government as represented by the Administrator
+of the National Aeronautics and Space Administration and The Penn State
+Research Foundation. All rights reserved. This software is licensed under the
+Apache 2.0 License.

--- a/across/__init__.py
+++ b/across/__init__.py
@@ -1,0 +1,19 @@
+"""
+NASA Docket No. GSC-19,469-1, and identified as "Astrophysics Cross-Observatory
+Science Support (ACROSS) System
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.“
+
+Copyright © 2025 United States Government as represented by the Administrator
+of the National Aeronautics and Space Administration and The Penn State
+Research Foundation.  All rights reserved. This software is licensed under the
+Apache 2.0 License.
+"""


### PR DESCRIPTION
## Title

feat(legal): add NASA copyright notices

### Description

Adds required NASA legal notices to top level of module and README.md.

### Related Issue(s)

Resolves #69 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

Compliance with the following: "Make sure the Notices below are put into the Header file of the Main Program and in any ReadMe documents that accompany the software files."

### Testing

N/A
