### PR TITLE
chore: add missing parameters to get many methods

### DIFF
--- a/across/client/apis/schedule.py
+++ b/across/client/apis/schedule.py
@@ -51,6 +51,7 @@ class Schedule:
         telescope_ids: list[str | None] | None = None,
         telescope_names: list[str | None] | None = None,
         name: str | None = None,
+        include_observations: bool | None = None,
     ) -> sdk.PageSchedule:
         """
         Retrieve all unique schedules filtered by optional criteria.
@@ -84,6 +85,9 @@ class Schedule:
                 Filter by one or more telescope names.
             name (str | None, optional):
                 Filter by schedule name.
+            include_observations (bool | None, optional):
+                Include observations in returned schedules
+                (defaults to False)
 
         Returns:
             sdk.PageSchedule:
@@ -103,6 +107,7 @@ class Schedule:
             telescope_ids=telescope_ids,
             telescope_names=telescope_names,
             name=name,
+            include_observations=include_observations,
         )
 
     def get_history(
@@ -120,6 +125,7 @@ class Schedule:
         telescope_ids: list[str | None] | None = None,
         telescope_names: list[str | None] | None = None,
         name: str | None = None,
+        include_observations: bool | None = None,
     ) -> sdk.PageSchedule:
         """
         Retrieve all schedules filtered by optional criteria.
@@ -151,6 +157,9 @@ class Schedule:
                 Filter by one or more telescope names.
             name (str | None, optional):
                 Filter by schedule name.
+            include_observations (bool | None, optional):
+                Include observations in returned schedules
+                (defaults to False)
 
         Returns:
             sdk.PageSchedule:
@@ -170,6 +179,7 @@ class Schedule:
             telescope_ids=telescope_ids,
             telescope_names=telescope_names,
             name=name,
+            include_observations=include_observations,
         )
 
     def post(self, schedule: sdk.ScheduleCreate) -> str:

--- a/across/client/apis/telescope.py
+++ b/across/client/apis/telescope.py
@@ -42,6 +42,8 @@ class Telescope:
         instrument_name: str | None = None,
         instrument_id: str | None = None,
         created_on: datetime | None = None,
+        include_filters: bool | None = None,
+        include_footprints: bool | None = None,
     ) -> list[sdk.Telescope]:
         """
         Retrieve multiple telescopes filtered by optional criteria.
@@ -55,6 +57,12 @@ class Telescope:
                 Filter by instrument ID.
             created_on (datetime | None, optional):
                 Filter by creation timestamp.
+            include_filters (bool | None, optional):
+                Include telescope instrument filters with the
+                returned values (defaults to False)
+            include_footprints (bool | None, optional):
+                Include telescope instrument footprints with the
+                returned values (defaults to False)
 
         Returns:
             list[sdk.Telescope]:
@@ -65,4 +73,6 @@ class Telescope:
             instrument_name=instrument_name,
             instrument_id=instrument_id,
             created_on=created_on,
+            include_filters=include_filters,
+            include_footprints=include_footprints,
         )

--- a/examples/001_accessing_SSA_model_data.ipynb
+++ b/examples/001_accessing_SSA_model_data.ipynb
@@ -222,7 +222,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "And there's a `get` method to look up a `Telescope` by `UUID`:"
+    "The `get_many` method also has two optional flags: `include_filters` and `include_footprints`. By default, the `Filters` and `Footprints` for the `Instruments` belonging to the retrieved `Telescope` objects are not returned. However, setting either of these flags to `True` will return their associated data.\n",
+    "\n",
+    "`Filters` describe the wavelength ranges an `Instrument` can observe. For more detail, see Section 2.4 below. Here is a quick example demonstrating accessing `Filter` information for an `Instrument` on the retrieved `Telescope`:"
    ]
   },
   {
@@ -231,12 +233,76 @@
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Name: Swift XRT\n",
+      "Min wavelength: 1.2 Angstrom\n",
+      "Max wavelength: 41.3 Angstrom\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Return filters for the instruments on a telescope\n",
+    "telescopes = client.telescope.get_many(name=\"XRT\", include_filters=True)\n",
+    "filt = telescopes[0].instruments[0].filters[0]\n",
+    "print(f\"Name: {filt.name}\")\n",
+    "print(f\"Min wavelength: {filt.min_wavelength:.1f} Angstrom\")\n",
+    "print(f\"Max wavelength: {filt.max_wavelength:.1f} Angstrom\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`Footprints` describe the area of the sky that a detector covers in a single observation. In the ACROSS system, they are represented by a series of points defining the vertices of a polygon, in units of degrees:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Point(x=-0.1416666666666667, y=-0.1416666666666667),\n",
+       " Point(x=0.1416666666666667, y=-0.1416666666666667),\n",
+       " Point(x=0.1416666666666667, y=0.1416666666666667),\n",
+       " Point(x=-0.1416666666666667, y=0.1416666666666667),\n",
+       " Point(x=-0.1416666666666667, y=-0.1416666666666667)]"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Return footprints for the instruments on a telescope\n",
+    "telescopes = client.telescope.get_many(name=\"UVOT\", include_footprints=True)\n",
+    "telescopes[0].instruments[0].footprints[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, there's a `get` method to look up a `Telescope` by `UUID`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
      "data": {
       "text/plain": [
        "'UV/Optical Telescope'"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -257,7 +323,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -266,7 +332,7 @@
        "'Near-Infrared Camera'"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -280,7 +346,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -289,7 +355,7 @@
        "'Near-Infrared Camera'"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -311,7 +377,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -342,7 +408,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -376,7 +442,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -385,7 +451,7 @@
      "text": [
       "Page: 1\n",
       "Number of schedules returned: 10\n",
-      "Total number of schedules: 49\n"
+      "Total number of schedules: 177\n"
      ]
     }
    ],
@@ -408,7 +474,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -416,21 +482,21 @@
      "output_type": "stream",
      "text": [
       "{\n",
-      "    \"telescope_id\": \"f2ae30ec-cd64-41b1-a951-4da29aa9f4ab\",\n",
-      "    \"name\": \"XMM_Newton_planned_2025-10-21_2025-10-31\",\n",
+      "    \"telescope_id\": \"281a5a5d-3629-4aa3-a739-968bee65415f\",\n",
+      "    \"name\": \"nustar_low_fidelity_planned_2025-11-20_2025-11-26\",\n",
       "    \"date_range\": {\n",
-      "        \"begin\": \"2025-10-21T12:13:52\",\n",
-      "        \"end\": \"2025-10-31T19:43:14\"\n",
+      "        \"begin\": \"2025-11-20T12:45:03\",\n",
+      "        \"end\": \"2025-11-26T14:00:00\"\n",
       "    },\n",
       "    \"status\": \"planned\",\n",
       "    \"external_id\": null,\n",
       "    \"fidelity\": \"low\",\n",
-      "    \"id\": \"b7b0d25c-bc58-48fd-b173-968ee8f2e911\",\n",
+      "    \"id\": \"7db48692-2832-4f48-9130-bac01da3bba6\",\n",
       "    \"observations\": [],\n",
-      "    \"observation_count\": 190,\n",
-      "    \"created_on\": \"2025-10-21T09:00:21.754546\",\n",
-      "    \"created_by_id\": \"e5aa65a1-b231-46e2-aded-381082917a23\",\n",
-      "    \"checksum\": \"ec4601f7214b4cde3ed0196177a83ce3749ddca5ea362569c14a8eb95b05e65851d205d54331935f1a4cac30b9432677bd0cfcc6cd995e16cf6d68ca434896e5\"\n",
+      "    \"observation_count\": 7,\n",
+      "    \"created_on\": \"2025-11-22T01:07:01.071060\",\n",
+      "    \"created_by_id\": \"1022155f-f13d-4ade-ac73-3d1941f612da\",\n",
+      "    \"checksum\": \"bd82609d4f044f761b15fa5102a5bf26a92efff47b8223ef9acd1e1709aa1a7e4ee104d0c17fe32f9366ffb2b2ea4c55c98e39893363d0d4510875767f53e87f\"\n",
       "}\n"
      ]
     }
@@ -443,19 +509,105 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you only want to know about the most up-to-date schedules in the ACROSS system, there's also a `get_history` endpoint, which returns only the most-recently submitted schedule per telescope in a specified date-range: "
+    "By default, getting `Schedules` will not return their associated `Observations` in order to reduce the size of the returned data. However, users can specify if they want the `Observations` belonging to that `Schedule` returned as well, using the `include_observations` flag:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Number of recent schedules: 51\n"
+      "Number of observations: 7\n",
+      "{\n",
+      "    \"instrument_id\": \"8e3f11f7-c943-4b45-b55e-59d475a4114f\",\n",
+      "    \"object_name\": \"SWIFTJ2036d0m0028\",\n",
+      "    \"pointing_position\": {\n",
+      "        \"ra\": 308.98929,\n",
+      "        \"dec\": -0.4602\n",
+      "    },\n",
+      "    \"date_range\": {\n",
+      "        \"begin\": \"2025-11-20T12:45:03\",\n",
+      "        \"end\": \"2025-11-21T05:50:00\"\n",
+      "    },\n",
+      "    \"external_observation_id\": \"91101647002\",\n",
+      "    \"type\": \"timing\",\n",
+      "    \"status\": \"planned\",\n",
+      "    \"pointing_angle\": 0.0,\n",
+      "    \"exposure_time\": 33300.0,\n",
+      "    \"reason\": null,\n",
+      "    \"description\": null,\n",
+      "    \"proposal_reference\": null,\n",
+      "    \"object_position\": {\n",
+      "        \"ra\": null,\n",
+      "        \"dec\": null\n",
+      "    },\n",
+      "    \"depth\": null,\n",
+      "    \"bandpass\": {\n",
+      "        \"anyof_schema_1_validator\": null,\n",
+      "        \"anyof_schema_2_validator\": null,\n",
+      "        \"anyof_schema_3_validator\": null,\n",
+      "        \"actual_instance\": {\n",
+      "            \"filter_name\": \"NuSTAR\",\n",
+      "            \"min\": 0.1581431102464288,\n",
+      "            \"max\": 4.132806614440008,\n",
+      "            \"type\": \"WAVELENGTH\",\n",
+      "            \"central_wavelength\": 2.1454748623432183,\n",
+      "            \"peak_wavelength\": null,\n",
+      "            \"bandwidth\": 1.9873317520967895,\n",
+      "            \"unit\": \"angstrom\"\n",
+      "        },\n",
+      "        \"any_of_schemas\": [\n",
+      "            \"EnergyBandpass\",\n",
+      "            \"FrequencyBandpass\",\n",
+      "            \"WavelengthBandpass\"\n",
+      "        ]\n",
+      "    },\n",
+      "    \"t_resolution\": null,\n",
+      "    \"em_res_power\": null,\n",
+      "    \"o_ucd\": null,\n",
+      "    \"pol_states\": null,\n",
+      "    \"pol_xel\": null,\n",
+      "    \"category\": null,\n",
+      "    \"priority\": null,\n",
+      "    \"tracking_type\": null,\n",
+      "    \"id\": \"31a12370-30b6-4252-ae18-c61efd3cb985\",\n",
+      "    \"schedule_id\": \"7db48692-2832-4f48-9130-bac01da3bba6\",\n",
+      "    \"created_on\": \"2025-11-22T01:07:01.124238\",\n",
+      "    \"created_by_id\": null\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "schedule = client.schedule.get_many(\n",
+    "    page=1, page_limit=1, fidelity=\"low\", status=\"planned\", include_observations=True\n",
+    ")\n",
+    "schedule_observations = schedule.items[0].observations\n",
+    "print(f\"Number of observations: {len(schedule_observations)}\")\n",
+    "print(schedule_observations[0].model_dump_json(indent=4))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you only want to know about the most up-to-date schedules in the ACROSS system, there's also a `get_history` endpoint, which returns only the most-recently submitted schedule per telescope in a specified date-range: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of recent schedules: 182\n"
      ]
     }
    ],
@@ -469,12 +621,38 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "`get_history` also has an optional `include_observations` flag, which works in the same way as for `get_many`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of observations: 8497\n"
+     ]
+    }
+   ],
+   "source": [
+    "schedule = client.schedule.get_history(page=1, page_limit=1, status=\"planned\", include_observations=True)\n",
+    "schedule_observations = schedule.items[0].observations\n",
+    "print(f\"Number of observations: {len(schedule_observations)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "And finally, there's a `get` endpoint to look up a schedule by its known UUID:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -482,21 +660,21 @@
      "output_type": "stream",
      "text": [
       "{\n",
-      "    \"telescope_id\": \"f2ae30ec-cd64-41b1-a951-4da29aa9f4ab\",\n",
-      "    \"name\": \"XMM_Newton_planned_2025-10-21_2025-10-31\",\n",
+      "    \"telescope_id\": \"222d5f4a-8fd6-4299-a696-b3a6cb13d7bc\",\n",
+      "    \"name\": \"fermi_lat_week_913\",\n",
       "    \"date_range\": {\n",
-      "        \"begin\": \"2025-10-21T12:13:52\",\n",
-      "        \"end\": \"2025-10-31T19:43:14\"\n",
+      "        \"begin\": \"2025-11-26T23:58:55\",\n",
+      "        \"end\": \"2025-12-03T23:50:55\"\n",
       "    },\n",
       "    \"status\": \"planned\",\n",
       "    \"external_id\": null,\n",
-      "    \"fidelity\": \"low\",\n",
-      "    \"id\": \"b7b0d25c-bc58-48fd-b173-968ee8f2e911\",\n",
+      "    \"fidelity\": \"high\",\n",
+      "    \"id\": \"7a94a265-c1e0-4f53-b712-6bb5f5c539ef\",\n",
       "    \"observations\": [],\n",
-      "    \"observation_count\": 190,\n",
-      "    \"created_on\": \"2025-10-21T09:00:21.754546\",\n",
-      "    \"created_by_id\": \"e5aa65a1-b231-46e2-aded-381082917a23\",\n",
-      "    \"checksum\": \"ec4601f7214b4cde3ed0196177a83ce3749ddca5ea362569c14a8eb95b05e65851d205d54331935f1a4cac30b9432677bd0cfcc6cd995e16cf6d68ca434896e5\"\n",
+      "    \"observation_count\": 8497,\n",
+      "    \"created_on\": \"2025-11-22T02:22:37.345065\",\n",
+      "    \"created_by_id\": \"1022155f-f13d-4ade-ac73-3d1941f612da\",\n",
+      "    \"checksum\": \"bfec4a59d40a0fc8e29659677229c2d49e3cfb902c00c5a0ffe75dd92e5d250ae3f5ecfd2dff6a536956792ef4dc0cd47185799a243c3495e3647085a7f549e8\"\n",
       "}\n"
      ]
     }
@@ -517,12 +695,12 @@
     "\n",
     "Like `Schedule` objects, `Observations` can be optionally paginated.\n",
     "\n",
-    "To retrieve many `Observations`, use the `get_many` method with any number of optional input parameters. Here we will demonstrate the most common ones:"
+    "To retrieve many `Observations` (across one or many `Schedules`), use the `get_many` method with any number of optional input parameters. Here we will demonstrate the most common ones:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -530,27 +708,27 @@
      "output_type": "stream",
      "text": [
       "{\n",
-      "    \"instrument_id\": \"1c074192-f6d5-465d-844e-85a0010b2d87\",\n",
-      "    \"object_name\": \"GRB 251011B\",\n",
+      "    \"instrument_id\": \"9899d36c-9e07-4927-8295-04c4ced70f1a\",\n",
+      "    \"object_name\": \"NGC-1846\",\n",
       "    \"pointing_position\": {\n",
-      "        \"ra\": 13.22209,\n",
-      "        \"dec\": -62.00911\n",
+      "        \"ra\": 76.92875,\n",
+      "        \"dec\": -67.47457\n",
       "    },\n",
       "    \"date_range\": {\n",
-      "        \"begin\": \"2025-10-20T23:40:00\",\n",
-      "        \"end\": \"2025-10-21T00:00:00\"\n",
+      "        \"begin\": \"2025-10-20T18:51:25\",\n",
+      "        \"end\": \"2025-10-20T22:34:25\"\n",
       "    },\n",
-      "    \"external_observation_id\": \"01403191007\",\n",
+      "    \"external_observation_id\": \"9012:1:2\",\n",
       "    \"type\": \"imaging\",\n",
       "    \"status\": \"planned\",\n",
-      "    \"pointing_angle\": 193.682286530267,\n",
-      "    \"exposure_time\": 1200.0,\n",
+      "    \"pointing_angle\": 0.0,\n",
+      "    \"exposure_time\": 13380.0,\n",
       "    \"reason\": null,\n",
       "    \"description\": null,\n",
       "    \"proposal_reference\": null,\n",
       "    \"object_position\": {\n",
-      "        \"ra\": 13.22209,\n",
-      "        \"dec\": -62.00911\n",
+      "        \"ra\": 76.92875,\n",
+      "        \"dec\": -67.47457\n",
       "    },\n",
       "    \"depth\": null,\n",
       "    \"bandpass\": {\n",
@@ -558,13 +736,13 @@
       "        \"anyof_schema_2_validator\": null,\n",
       "        \"anyof_schema_3_validator\": null,\n",
       "        \"actual_instance\": {\n",
-      "            \"filter_name\": \"Swift UVOT u\",\n",
-      "            \"min\": 3079.9999999999995,\n",
-      "            \"max\": 3849.9999999999995,\n",
+      "            \"filter_name\": \"F115W\",\n",
+      "            \"min\": 10130.0,\n",
+      "            \"max\": 12819.999999999996,\n",
       "            \"type\": \"WAVELENGTH\",\n",
-      "            \"central_wavelength\": 3464.9999999999995,\n",
+      "            \"central_wavelength\": 11474.999999999998,\n",
       "            \"peak_wavelength\": null,\n",
-      "            \"bandwidth\": 385.0,\n",
+      "            \"bandwidth\": 1344.9999999999982,\n",
       "            \"unit\": \"angstrom\"\n",
       "        },\n",
       "        \"any_of_schemas\": [\n",
@@ -581,9 +759,9 @@
       "    \"category\": null,\n",
       "    \"priority\": null,\n",
       "    \"tracking_type\": null,\n",
-      "    \"id\": \"145a87aa-42ee-47b2-9151-02a657e8438f\",\n",
-      "    \"schedule_id\": \"7eca04a9-9bbe-4f17-b005-f4eaf53013f8\",\n",
-      "    \"created_on\": \"2025-10-20T22:44:26.551739\",\n",
+      "    \"id\": \"0c16cbd8-3249-490b-91b1-6dd0db355bfc\",\n",
+      "    \"schedule_id\": \"f52c037a-05e1-4826-ab25-1facf42adcec\",\n",
+      "    \"created_on\": \"2025-10-23T22:33:10.953690\",\n",
       "    \"created_by_id\": null\n",
       "}\n"
      ]
@@ -601,14 +779,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Number of observations returned: 4\n"
+      "Number of observations returned: 18\n"
      ]
     }
    ],
@@ -620,14 +798,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Number of observations returned: 854\n",
+      "Number of observations returned: 6132\n",
       "The same process can be used to get observations by telescope, instrument, and schedule ID\n"
      ]
     }
@@ -642,14 +820,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Number of observations returned: 1200\n"
+      "Number of observations returned: 4214\n"
      ]
     }
    ],
@@ -661,14 +839,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Number of observations returned: 34034\n"
+      "Number of observations returned: 111933\n"
      ]
     }
    ],

--- a/tests/apis/schedule/test_schedule.py
+++ b/tests/apis/schedule/test_schedule.py
@@ -60,6 +60,19 @@ class TestGetMany:
         result = schedule.get_many()
         assert result == fake_page_schedule
 
+    def test_should_optionally_return_observations(self, mock_schedule_api: MagicMock) -> None:
+        """
+        Ensure that `Schedule.get_many()` returns a list of
+        observations when `include_observations` is set to `True`.
+        Args:
+            mock_schedule_api (MagicMock):
+                A mocked instance of `ScheduleApi`.
+        """
+        schedule = Schedule(across_client=MagicMock())
+        schedule.get_many(include_observations=True)
+        call = mock_schedule_api.get_schedules.call_args_list[0]
+        assert call.kwargs["include_observations"] is True
+
 
 class TestGetHistory:
     """
@@ -77,6 +90,19 @@ class TestGetHistory:
         schedule = Schedule(across_client=MagicMock())
         result = schedule.get_history()
         assert result == fake_page_schedule
+
+    def test_should_optionally_return_observations(self, mock_schedule_api: MagicMock) -> None:
+        """
+        Ensure that `Schedule.get_history()` returns a list of
+        observations when `include_observations` is set to `True`.
+        Args:
+            mock_schedule_api (MagicMock):
+                A mocked instance of `ScheduleApi`.
+        """
+        schedule = Schedule(across_client=MagicMock())
+        schedule.get_history(include_observations=True)
+        call = mock_schedule_api.get_schedules_history.call_args_list[0]
+        assert call.kwargs["include_observations"] is True
 
 
 class TestPost:

--- a/tests/apis/telescope/test_telescope.py
+++ b/tests/apis/telescope/test_telescope.py
@@ -58,3 +58,35 @@ class TestGetMany:
         telescope = Telescope(across_client=MagicMock())
         result = telescope.get_many()
         assert result == [fake_telescope]
+
+    def test_should_optionally_return_instrument_footprints(
+        self,
+        mock_telescope_api: MagicMock,
+    ) -> None:
+        """
+        Ensure that `Telescope.get_many()` returns instrument footprints
+        when `include_footprints` is set to `True`.
+        Args:
+            mock_telescope_api (MagicMock):
+                A mocked instance of `TelescopeApi`.
+        """
+        telescope = Telescope(across_client=MagicMock())
+        telescope.get_many(include_footprints=True)
+        call = mock_telescope_api.get_telescopes.call_args_list[0]
+        assert call.kwargs["include_footprints"] is True
+
+    def test_should_optionally_return_instrument_filters(
+        self,
+        mock_telescope_api: MagicMock,
+    ) -> None:
+        """
+        Ensure that `Telescope.get_many()` returns instrument filters
+        when `include_filters` is set to `True`.
+        Args:
+            mock_telescope_api (MagicMock):
+                A mocked instance of `TelescopeApi`.
+        """
+        telescope = Telescope(across_client=MagicMock())
+        telescope.get_many(include_filters=True)
+        call = mock_telescope_api.get_telescopes.call_args_list[0]
+        assert call.kwargs["include_filters"] is True


### PR DESCRIPTION
### Description

This PR adds a few missing optional parameters to some of the SSA model methods. This includes:
  - `include_footprints` and `include_filters` in `Telescope.get_many`
  - `include_observations` in `Schedule.get_many` and `Schedule.get_history`
 
I added tests to cover these parameters to ensure they get passed along to the related `sdk` objects. I also updated the example notebook to show how to use them.

### Related Issue(s)

Resolves #15 

### Reviewers

@ACROSS-Team/developers 

### Acceptance Criteria

1. `Telescope.get_many` should accept `include_footprints` and `include_filters` as inputs and use them to optionally return related instrument values
2. `Schedule.get_many` and `Schedule.get_history` should accept `include_observations` as input and use it to optionally return observations for the retrieved schedules
3. These values should all default to `False` and the related objects should not be returned unless specified otherwise

### Testing

1. In a python shell or notebook, init the client 
2. Test the above methods with the optional `include_...` parameters and verify the related data is returned or not returned as expected
3. Verify tests all pass
4. Verify example notebook looks alright