### PR TITLE
fix: tests need right datetime type from sdk in vis calc

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dynamic = ["version"]
 requires-python = ">=3.10"
 dependencies = [
     "across-tools",
-    "across-server-openapi-python>=1.1.0",
+    "across-server-openapi-python>=1.2.0",
 ]
 
 [project.urls]

--- a/tests/apis/tools/conftest.py
+++ b/tests/apis/tools/conftest.py
@@ -49,7 +49,6 @@ def fake_date_range() -> sdk.DateRange:
 
 @pytest.fixture
 def fake_visibility_window(
-    fake_date_range: sdk.DateRange,
     fake_observatory_id: str,
 ) -> sdk.VisibilityWindow:
     """
@@ -58,12 +57,12 @@ def fake_visibility_window(
     return sdk.VisibilityWindow(
         window=sdk.Window(
             begin=sdk.ConstrainedDate(
-                datetime=fake_date_range.begin,
+                datetime=sdk.Datetime("2025-10-23T00:00:00.00"),
                 constraint=sdk.ConstraintType.TEST_CONSTRAINT,
                 observatory_id=fake_observatory_id,
             ),
             end=sdk.ConstrainedDate(
-                datetime=fake_date_range.end,
+                datetime=sdk.Datetime("2025-10-23T01:00:00.00"),
                 constraint=sdk.ConstraintType.TEST_CONSTRAINT,
                 observatory_id=fake_observatory_id,
             ),


### PR DESCRIPTION
### Description

This PR fixes a breaking test from the SDK updates.

### Related Issue(s)

#52 

### Reviewers

@NASA-ACROSS/developers 

### Acceptance Criteria

tests pass

### Testing

run tests 🍏