### PR TITLE
fix(config): Update api url

### DIFF
--- a/across/client/core/config.py
+++ b/across/client/core/config.py
@@ -14,7 +14,7 @@ class Config(BaseConfig):
     Core configuratiaon for across.client
     """
 
-    HOST: str = "https://server.prod.across.smce.nasa.gov/api/v1"
+    HOST: str = "https://api.across.sciencecloud.nasa.gov/v1/"
     ACROSS_SERVER_ID: str | None = None
     ACROSS_SERVER_SECRET: str | None = None
 


### PR DESCRIPTION
### Description

Everything is currently broken since our server URL has changed. This fixes it

### Related Issue(s)

#56 

### Reviewers

@NASA-ACROSS/scientists 

### Acceptance Criteria

Client can communicate with server appropriately

### Testing

```python
from across.client import Client

client = Client()

print(client.across_client.configuration.host)
>>> https://api.across.sciencecloud.nasa.gov/v1/
```