### PR TITLE
feat(telescope): adding observatory params to get many

### DIFF
--- a/across/client/apis/telescope.py
+++ b/across/client/apis/telescope.py
@@ -39,6 +39,8 @@ class Telescope:
     def get_many(
         self,
         name: str | None = None,
+        observatory_id: str | None = None,
+        observatory_name: str | None = None,
         instrument_name: str | None = None,
         instrument_id: str | None = None,
         created_on: datetime | None = None,
@@ -51,6 +53,10 @@ class Telescope:
         Args:
             name (str | None, optional):
                 Filter by telescope name.
+            observatory_id (str | None, optional):
+                Filter by observatory ID.
+            observatory_name (str | None, optional):
+                Filter by observatory name.
             instrument_name (str | None, optional):
                 Filter by instrument name.
             instrument_id (str | None, optional):
@@ -70,6 +76,8 @@ class Telescope:
         """
         return sdk.TelescopeApi(self.across_client).get_telescopes(
             name=name,
+            observatory_id=observatory_id,
+            observatory_name=observatory_name,
             instrument_name=instrument_name,
             instrument_id=instrument_id,
             created_on=created_on,


### PR DESCRIPTION
### Description

Adds `observatory_name` and `observatory_id` to `telescope.get_many()`

### Related Issue(s)

#55 

### Reviewers

@NASA-ACROSS/scientists 

### Acceptance Criteria

Users can query for telescopes based off of `observatory_name` and `observatory_id`

### Testing

1. pull current version of across-server, with up-todate seeded database
2. The prod api isn't up-todate, so change L:17 of `across/client/core/config.py` to 
```
HOST: str = "http://127.0.0.1:8000/v1"
```
3. Run this:
```python
from across.client import Client
client = Client()
client.telescope.get_many(observatory_id="9864f892-a980-442c-a0c9-f35e26e598dd")
>>> ixpe telescope
```