### PR TITLE
fix: install uv in pypi publish

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -22,9 +22,9 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - uses: astral-sh/setup-uv@v8.1.0
         with:
+          activate-environment: true
           python-version: "3.10"
       - name: Install dependencies
         run: |


### PR DESCRIPTION
### Description

should fix missing `uv`

### Related Issue(s)

Resolves #61 
