### PR TITLE
feat: add observation contains point functionality

### DIFF
--- a/across/client/apis/observation.py
+++ b/across/client/apis/observation.py
@@ -52,7 +52,7 @@ class Observation:
         date_range_end: datetime | None = None,
         bandpass_min: float | None = None,
         bandpass_max: float | None = None,
-        bandpass_type: sdk.WavelengthBandpass | sdk.EnergyBandpass | sdk.FrequencyBandpass | None = None,
+        bandpass_type: sdk.WavelengthUnit | sdk.EnergyUnit | sdk.FrequencyUnit | None = None,
         cone_search_ra: float | None = None,
         cone_search_dec: float | None = None,
         cone_search_radius: float | None = None,
@@ -92,8 +92,8 @@ class Observation:
                 Minimum bandpass value (in the unit defined by `bandpass_type`).
             bandpass_max (float | None):
                 Maximum bandpass value (in the unit defined by `bandpass_type`).
-            bandpass_type (sdk.WavelengthBandpass | sdk.EnergyBandpass | sdk.FrequencyBandpass | None):
-                Type of bandpass measurement (wavelength, energy, or frequency).
+            bandpass_type (sdk.WavelengthUnit | sdk.EnergyUnit| sdk.FrequencyUnit | None):
+                Unit of bandpass measurement (wavelength, energy, or frequency unit).
             cone_search_ra (float | None):
                 Right Ascension (RA) for cone search, in degrees.
             cone_search_dec (float | None):
@@ -133,4 +133,105 @@ class Observation:
             type=type,
             depth_value=depth_value,
             depth_unit=depth_unit,
+        )
+
+    def contains_point(
+        self,
+        ra: float,
+        dec: float,
+        page: int | None = None,
+        page_limit: int | None = None,
+        external_id: str | None = None,
+        schedule_ids: list[str] | None = None,
+        observatory_ids: list[str] | None = None,
+        telescope_ids: list[str] | None = None,
+        instrument_ids: list[str] | None = None,
+        status: sdk.ObservationStatus | None = None,
+        proposal: str | None = None,
+        object_name: str | None = None,
+        date_range_begin: datetime | None = None,
+        date_range_end: datetime | None = None,
+        bandpass_min: float | None = None,
+        bandpass_max: float | None = None,
+        bandpass_type: sdk.WavelengthUnit | sdk.EnergyUnit | sdk.FrequencyUnit | None = None,
+        type: sdk.ObservationType | None = None,
+        depth_value: float | None = None,
+        depth_unit: sdk.DepthUnit | None = None,
+        include_footprints: bool | None = None,
+    ) -> sdk.PageObservation:
+        """
+        Retrieve multiple observations that contain a given point,
+        filtered by optional criteria.
+
+        Args:
+            ra (float | None):
+                Right Ascension (RA) of the point, in degrees.
+            dec (float | None):
+                Declination (Dec) of the point, in degrees.
+            page (int | None):
+                Filter by pagination page
+            page_limit (int | None):
+                Filter by number of records per page
+            external_id (str | None):
+                Filter by an external identifier.
+            schedule_ids (list[str | None] | None):
+                Filter by one or more schedule IDs.
+            observatory_ids (list[str] | None):
+                Filter by one or more observatory IDs.
+            telescope_ids (list[str] | None):
+                Filter by one or more telescope IDs.
+            instrument_ids (list[str] | None):
+                Filter by one or more instrument IDs.
+            status (sdk.ObservationStatus | None):
+                Filter by observation status.
+            proposal (str | None):
+                Filter by proposal identifier or name.
+            object_name (str | None):
+                Filter by target object name.
+            date_range_begin (datetime | None):
+                Filter for observations starting on or after this date.
+            date_range_end (datetime | None):
+                Filter for observations ending on or before this date.
+            bandpass_min (float | None):
+                Minimum bandpass value (in the unit defined by `bandpass_type`).
+            bandpass_max (float | None):
+                Maximum bandpass value (in the unit defined by `bandpass_type`).
+            bandpass_type (sdk.WavelengthUnit | sdk.EnergyUnit | sdk.FrequencyUnit | None):
+                Unit of the bandpass measurement.
+            type (sdk.ObservationType | None):
+                Filter by observation type.
+            depth_value (float | None):
+                Sensitivity or depth threshold value.
+            depth_unit (sdk.DepthUnit | None):
+                Unit for `depth_value`.
+            include_footprints (bool | None):
+                Optionally include footprint of the observation.
+
+        Returns:
+            list[sdk.Observation]:
+                A list of observations matching the given filters that overlap with the
+                given point.
+        """
+        return sdk.ObservationApi(self.across_client).contains_point(
+            ra=ra,
+            dec=dec,
+            page=page,
+            page_limit=page_limit,
+            external_id=external_id,
+            schedule_ids=schedule_ids,
+            observatory_ids=observatory_ids,
+            telescope_ids=telescope_ids,
+            instrument_ids=instrument_ids,
+            status=status,
+            proposal=proposal,
+            object_name=object_name,
+            date_range_begin=date_range_begin,
+            date_range_end=date_range_end,
+            bandpass_min=bandpass_min,
+            bandpass_max=bandpass_max,
+            bandpass_type=bandpass_type,
+            type=type,
+            depth_value=depth_value,
+            depth_unit=depth_unit,
+            include_footprints=include_footprints,
         )

--- a/docs/notebooks/001_accessing_SSA_model_data.ipynb
+++ b/docs/notebooks/001_accessing_SSA_model_data.ipynb
@@ -107,7 +107,8 @@
       "Spectro-Photometer for the History of the Universe, Epoch of Reionization, and Ices Explorer\n",
       "Pandora Observatory\n",
       "Euclid Observatory\n",
-      "X-ray Imaging and Spectroscopy Mission\n"
+      "X-ray Imaging and Spectroscopy Mission\n",
+      "Star-Planet Activity Research CubeSat\n"
      ]
     }
    ],
@@ -455,7 +456,7 @@
      "text": [
       "Page: 1\n",
       "Number of schedules returned: 10\n",
-      "Total number of schedules: 1219\n"
+      "Total number of schedules: 1382\n"
      ]
     }
    ],
@@ -486,21 +487,21 @@
      "output_type": "stream",
      "text": [
       "{\n",
-      "    \"telescope_id\": \"d18710e4-2a21-4dc6-8a57-eff0f46fc5f7\",\n",
-      "    \"name\": \"rubin_low_fidelity_planned_2026-05-22_2026-05-23\",\n",
+      "    \"telescope_id\": \"f2ae30ec-cd64-41b1-a951-4da29aa9f4ab\",\n",
+      "    \"name\": \"XMM_Newton_planned_2026-06-18_2026-07-18\",\n",
       "    \"date_range\": {\n",
-      "        \"begin\": \"2026-05-22T22:39:27.414257\",\n",
-      "        \"end\": \"2026-05-23T10:40:48.617665\"\n",
+      "        \"begin\": \"2026-06-18T12:09:37\",\n",
+      "        \"end\": \"2026-07-18T02:29:08\"\n",
       "    },\n",
       "    \"status\": \"planned\",\n",
       "    \"external_id\": null,\n",
       "    \"fidelity\": \"low\",\n",
-      "    \"id\": \"9012bd2d-17d2-48ee-8ee3-b5435d7236fb\",\n",
+      "    \"id\": \"189758df-a9c9-4ce5-9800-d6a63f9d2d76\",\n",
       "    \"observations\": [],\n",
-      "    \"observation_count\": 1003,\n",
-      "    \"created_on\": \"2026-05-22T18:00:09.576334\",\n",
+      "    \"observation_count\": 464,\n",
+      "    \"created_on\": \"2026-06-18T09:00:15.025364\",\n",
       "    \"created_by_id\": \"1022155f-f13d-4ade-ac73-3d1941f612da\",\n",
-      "    \"checksum\": \"e7c3db2f87b9d05ad8c50217539db438985d0d48af06988e117f6a9d2792601e2de1f908aef5869145d6abac9fe93ce4677ca02d22015f56fe7ac400ac9a6f9f\"\n",
+      "    \"checksum\": \"4e42ea60830b0964b6d680e43388a226c850cde4d7a77e41c78a732aa63199d3422d9f6f7d9dc2d19951f36cd171844b6f30174f6d7fac9f936dce28ba45c9b2\"\n",
       "}\n"
      ]
     }
@@ -525,29 +526,29 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Number of observations: 1003\n",
+      "Number of observations: 464\n",
       "{\n",
-      "    \"instrument_id\": \"b9342e4c-1106-4e47-a434-30c639ce661b\",\n",
-      "    \"object_name\": \"lowdust\",\n",
+      "    \"instrument_id\": \"ab55be45-9796-40da-8125-e512f446ac96\",\n",
+      "    \"object_name\": \"CC Eri\",\n",
       "    \"pointing_position\": {\n",
-      "        \"ra\": 215.67474,\n",
-      "        \"dec\": 13.57232\n",
+      "        \"ra\": 38.59167,\n",
+      "        \"dec\": -43.79833\n",
       "    },\n",
       "    \"date_range\": {\n",
-      "        \"begin\": \"2026-05-23T02:10:28.007977\",\n",
-      "        \"end\": \"2026-05-23T02:30:58.007978\"\n",
+      "        \"begin\": \"2026-07-17T12:42:28\",\n",
+      "        \"end\": \"2026-07-18T02:10:48\"\n",
       "    },\n",
-      "    \"external_observation_id\": \"lowdust\",\n",
+      "    \"external_observation_id\": \"0982970101\",\n",
       "    \"type\": \"imaging\",\n",
       "    \"status\": \"planned\",\n",
-      "    \"pointing_angle\": 0.0,\n",
-      "    \"exposure_time\": 30.0,\n",
+      "    \"pointing_angle\": 64.58,\n",
+      "    \"exposure_time\": 48500.0,\n",
       "    \"reason\": null,\n",
       "    \"description\": null,\n",
       "    \"proposal_reference\": null,\n",
       "    \"object_position\": {\n",
-      "        \"ra\": null,\n",
-      "        \"dec\": null\n",
+      "        \"ra\": 38.59167,\n",
+      "        \"dec\": -43.79833\n",
       "    },\n",
       "    \"depth\": null,\n",
       "    \"bandpass\": {\n",
@@ -555,32 +556,32 @@
       "        \"anyof_schema_2_validator\": null,\n",
       "        \"anyof_schema_3_validator\": null,\n",
       "        \"actual_instance\": {\n",
-      "            \"filter_name\": \"rubin_i\",\n",
-      "            \"min\": 6916.0,\n",
-      "            \"max\": 8202.0,\n",
+      "            \"filter_name\": \"XMM-Newton EPIC\",\n",
+      "            \"min\": 1.0332016536100035,\n",
+      "            \"max\": 41.32806614440008,\n",
       "            \"type\": \"WAVELENGTH\",\n",
-      "            \"central_wavelength\": 7559.0,\n",
+      "            \"central_wavelength\": 21.18063389900504,\n",
       "            \"peak_wavelength\": null,\n",
-      "            \"bandwidth\": 643.0,\n",
+      "            \"bandwidth\": 20.147432245395038,\n",
       "            \"unit\": \"angstrom\"\n",
       "        },\n",
       "        \"any_of_schemas\": [\n",
-      "            \"EnergyBandpass\",\n",
+      "            \"WavelengthBandpass\",\n",
       "            \"FrequencyBandpass\",\n",
-      "            \"WavelengthBandpass\"\n",
+      "            \"EnergyBandpass\"\n",
       "        ]\n",
       "    },\n",
-      "    \"t_resolution\": 15.0,\n",
-      "    \"em_res_power\": 0.0,\n",
-      "    \"o_ucd\": \"phot.flux.density\",\n",
-      "    \"pol_states\": \"\",\n",
-      "    \"pol_xel\": \"0\",\n",
-      "    \"category\": \"fixed\",\n",
-      "    \"priority\": 0,\n",
-      "    \"tracking_type\": \"sidereal\",\n",
-      "    \"id\": \"12eefb2c-8595-493f-9e75-0b98b1e85857\",\n",
-      "    \"schedule_id\": \"9012bd2d-17d2-48ee-8ee3-b5435d7236fb\",\n",
-      "    \"created_on\": \"2026-05-22T18:00:09.666456\",\n",
+      "    \"t_resolution\": null,\n",
+      "    \"em_res_power\": null,\n",
+      "    \"o_ucd\": null,\n",
+      "    \"pol_states\": null,\n",
+      "    \"pol_xel\": null,\n",
+      "    \"category\": null,\n",
+      "    \"priority\": null,\n",
+      "    \"tracking_type\": null,\n",
+      "    \"id\": \"543e0706-532d-4b9b-9245-a22ce3996a39\",\n",
+      "    \"schedule_id\": \"189758df-a9c9-4ce5-9800-d6a63f9d2d76\",\n",
+      "    \"created_on\": \"2026-06-18T09:00:15.075349\",\n",
       "    \"created_by_id\": null,\n",
       "    \"footprint\": []\n",
       "}\n"
@@ -612,7 +613,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Number of recent schedules: 1246\n"
+      "Number of recent schedules: 1414\n"
      ]
     }
    ],
@@ -638,7 +639,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Number of observations: 1003\n"
+      "Number of observations: 464\n"
      ]
     }
    ],
@@ -665,21 +666,21 @@
      "output_type": "stream",
      "text": [
       "{\n",
-      "    \"telescope_id\": \"d18710e4-2a21-4dc6-8a57-eff0f46fc5f7\",\n",
-      "    \"name\": \"rubin_low_fidelity_planned_2026-05-22_2026-05-23\",\n",
+      "    \"telescope_id\": \"f2ae30ec-cd64-41b1-a951-4da29aa9f4ab\",\n",
+      "    \"name\": \"XMM_Newton_planned_2026-06-18_2026-07-18\",\n",
       "    \"date_range\": {\n",
-      "        \"begin\": \"2026-05-22T22:39:27.414257\",\n",
-      "        \"end\": \"2026-05-23T10:40:48.617665\"\n",
+      "        \"begin\": \"2026-06-18T12:09:37\",\n",
+      "        \"end\": \"2026-07-18T02:29:08\"\n",
       "    },\n",
       "    \"status\": \"planned\",\n",
       "    \"external_id\": null,\n",
       "    \"fidelity\": \"low\",\n",
-      "    \"id\": \"9012bd2d-17d2-48ee-8ee3-b5435d7236fb\",\n",
+      "    \"id\": \"189758df-a9c9-4ce5-9800-d6a63f9d2d76\",\n",
       "    \"observations\": [],\n",
-      "    \"observation_count\": 1003,\n",
-      "    \"created_on\": \"2026-05-22T18:00:09.576334\",\n",
+      "    \"observation_count\": 464,\n",
+      "    \"created_on\": \"2026-06-18T09:00:15.025364\",\n",
       "    \"created_by_id\": \"1022155f-f13d-4ade-ac73-3d1941f612da\",\n",
-      "    \"checksum\": \"e7c3db2f87b9d05ad8c50217539db438985d0d48af06988e117f6a9d2792601e2de1f908aef5869145d6abac9fe93ce4677ca02d22015f56fe7ac400ac9a6f9f\"\n",
+      "    \"checksum\": \"4e42ea60830b0964b6d680e43388a226c850cde4d7a77e41c78a732aa63199d3422d9f6f7d9dc2d19951f36cd171844b6f30174f6d7fac9f936dce28ba45c9b2\"\n",
       "}\n"
      ]
     }
@@ -751,9 +752,9 @@
       "            \"unit\": \"angstrom\"\n",
       "        },\n",
       "        \"any_of_schemas\": [\n",
-      "            \"EnergyBandpass\",\n",
+      "            \"WavelengthBandpass\",\n",
       "            \"FrequencyBandpass\",\n",
-      "            \"WavelengthBandpass\"\n",
+      "            \"EnergyBandpass\"\n",
       "        ]\n",
       "    },\n",
       "    \"t_resolution\": null,\n",
@@ -792,7 +793,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Number of observations returned: 29\n"
+      "Number of observations returned: 43\n"
      ]
     }
    ],
@@ -811,7 +812,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Number of observations returned: 21922\n",
+      "Number of observations returned: 25173\n",
       "The same process can be used to get observations by telescope, instrument, and schedule ID\n"
      ]
     }
@@ -833,7 +834,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Number of observations returned: 15044\n"
+      "Number of observations returned: 18352\n"
      ]
     }
    ],
@@ -852,7 +853,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Number of observations returned: 690657\n"
+      "Number of observations returned: 843523\n"
      ]
     }
    ],
@@ -866,13 +867,71 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "A user can also retrieve `Observations` that contain a point on the sky:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of observations returned: 2915\n"
+     ]
+    }
+   ],
+   "source": [
+    "# GET observations that contain a point\n",
+    "target_ra = 123.45\n",
+    "target_dec = -43.21\n",
+    "\n",
+    "observations = client.observation.contains_point(ra=target_ra, dec=target_dec)\n",
+    "print(f\"Number of observations returned: {observations.model_dump()['total_number']}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of observations returned: 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# GET observations that contain a point with a specific status and bandpass\n",
+    "target_ra = 123.45\n",
+    "target_dec = -43.21\n",
+    "\n",
+    "observations = client.observation.contains_point(\n",
+    "    ra=target_ra,\n",
+    "    dec=target_dec,\n",
+    "    status=\"planned\",\n",
+    "    bandpass_min=4500.0,\n",
+    "    bandpass_max=7000.0,\n",
+    "    bandpass_type=\"angstrom\",\n",
+    ")\n",
+    "print(f\"Number of observations returned: {observations.model_dump()['total_number']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "And as always there's a `get` method that behaves the same to the others demonstrated so far."
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -886,7 +945,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.6"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,

--- a/docs/schedules.rst
+++ b/docs/schedules.rst
@@ -405,6 +405,45 @@ supported through the ``client.observation.get_many()`` method:
     )
     observations = observations_page.items
 
+
+Retrieving Observations That Contain a Point
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In many scientific applications, a user may be interested in retrieving all observations that
+contain a specific point on the sky, e.g. a point source transient. This differs from a simple
+cone search because it accounts for the geometry of the instrument's footprint on the sky
+for a particular observation.
+
+The ACROSS client supports retrieving observations that contain a given (RA, dec) point through the
+``client.observation.contains_point()`` method:
+
+Example: Retrieve observations that contain a specific point
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Let's say a user knows of an interesting point source transient and wants to search for
+observations in a particular date and wavelength range that covered that transient's coordinate:
+
+.. code-block:: python
+
+    from across.client import Client
+    from datetime import datetime, timedelta
+
+    last_week = datetime.now() - timedelta(days=7)
+    target_ra = 123.45
+    target_dec = -54.32
+
+    client = Client()
+    observations_page = client.observation.contains_point(
+        ra=target_ra,
+        dec=target_dec,
+        date_range_begin=last_week,
+        bandpass_min=4000,
+        bandpass_max=7000,
+        bandpass_type="angstrom",
+    )
+    observations = observations_page.items
+
+
 Method Parameters
 ^^^^^^^^^^^^^^^^^^
 The ``client.observation.get_many()`` method takes a number of optional parameters as input. 
@@ -480,6 +519,81 @@ These are shown below:
    * - ``depth_unit``
      - str | None
      - Unit for the depth of the ``Observation`` (one of ``ab_mag``, ``vega_mag``, ``flux_erg``, or ``flux_jy``)
+
+
+The ``client.observation.contains_point()`` method takes a similar list of optional parameters.
+However, it requires an RA and Dec. The parameters are are shown below:
+
+.. list-table:: observation.contains_point() Parameters
+   :widths: 20 25 65
+   :header-rows: 1
+
+   * - Attribute
+     - Type
+     - Description
+   * - ``ra``
+     - float
+     - Right Ascension of the point
+   * - ``dec``
+     - float
+     - Declination of the point
+   * - ``page``
+     - int | None
+     - The page of ``Observation`` results to return
+   * - ``page_limit``
+     - int | None
+     - The maximum number of ``Observation`` objects per page to return
+   * - ``external_id``
+     - str | None
+     - Any external ID associated with the ``Observation``
+   * - ``schedule_ids``
+     - list[str] | None
+     - Include only ``Observations`` for ``Schedules`` with these IDs
+   * - ``observatory_ids``
+     - list[str] | None
+     - Include only ``Observations`` for ``Instruments`` on ``Telescopes`` belonging to the ``Observatories`` with these IDs
+   * - ``telescope_ids``
+     - list[str] | None
+     - Include only ``Observations`` for ``Instruments`` on ``Telescopes`` with these IDs   
+   * - ``instrument_ids``
+     - list[str] | None
+     - Include only ``Observations`` for ``Instruments`` with these IDs  
+   * - ``status``
+     - str | None
+     - ``Observation`` status (``planned``, ``scheduled``, ``unscheduled``, ``performed``, or ``aborted``) 
+   * - ``proposal``
+     - str | None
+     - Any external proposal name under which this ``Observation`` was submitted
+   * - ``object_name``
+     - str | None
+     - Name of target object, if it exists  
+   * - ``date_range_begin``
+     - datetime | None
+     - Datetime for ``Observations`` beginning on or after this date
+   * - ``date_range_end``
+     - datetime | None
+     - Datetime for ``Observations`` ending before or on this date
+   * - ``bandpass_min``
+     - float | None
+     - Minimum wavelength of bandpass for the ``Observation`` (in Angstroms)
+   * - ``bandpass_max``
+     - float | None
+     - Maximum wavelength of bandpass for the ``Observation`` (in Angstroms)
+   * - ``bandpass_type``
+     - str | None
+     - Unit of ``bandpass_min`` and ``bandpass_max`` (one of ``angstrom``, ``nm``, ``um``, or ``mm``)
+   * - ``type``
+     - str | None
+     - Type of the ``Observation`` (one of ``imaging``, ``spectroscopy``, ``timing``, or ``slew``)
+   * - ``depth_value``
+     - float | None
+     - Depth of the ``Observation``, in units of ``depth_unit``
+   * - ``depth_unit``
+     - str | None
+     - Unit for the depth of the ``Observation`` (one of ``ab_mag``, ``vega_mag``, ``flux_erg``, or ``flux_jy``)
+   * - ``include_footprints``
+     - bool | None
+     - Optionally include projected footprints for each observation
 
 ``Observation`` objects
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/apis/observation/conftest.py
+++ b/tests/apis/observation/conftest.py
@@ -69,6 +69,7 @@ def mock_observation_api(
     mock = MagicMock()
     mock.get_observations = MagicMock(return_value=fake_page_observation)
     mock.get_observation = MagicMock(return_value=fake_observation)
+    mock.contains_point = MagicMock(return_value=fake_page_observation)
     return mock
 
 

--- a/tests/apis/observation/test_observation.py
+++ b/tests/apis/observation/test_observation.py
@@ -1,6 +1,8 @@
 from unittest.mock import MagicMock
 from uuid import uuid4
 
+import pytest
+
 import across.sdk.v1 as sdk
 from across.client.apis import Observation
 
@@ -58,3 +60,67 @@ class TestGetMany:
         observation = Observation(across_client=MagicMock())
         result = observation.get_many()
         assert result == fake_page_observation
+
+
+class TestContainsPoint:
+    """
+    Unit tests for the `Observation.contains_point`.
+    """
+
+    def test_should_return_observations(self, fake_page_observation: sdk.PageObservation) -> None:
+        """
+        Ensure that `Observation.contains_point()` returns a list of
+        observations when the SDK call is mocked.
+        Args:
+            fake_page_observation (sdk.PageObservation):
+                A mocked `sdk.PageObservation` instance returned by the patched API.
+        """
+        observation = Observation(across_client=MagicMock())
+        result = observation.contains_point(ra=123.45, dec=-65.43)
+        assert result == fake_page_observation
+
+    @pytest.mark.parametrize(
+        "field, value",
+        [
+            ("page", 1),
+            ("page_limit", 50),
+            ("external_id", "test-id"),
+            ("schedule_ids", ["schedule-1", "schedule-2"]),
+            ("observatory_ids", ["obs-1"]),
+            ("telescope_ids", ["tel-1"]),
+            ("instrument_ids", ["inst-1"]),
+            ("status", sdk.ObservationStatus.SCHEDULED),
+            ("proposal", "test-proposal"),
+            ("object_name", "test-object"),
+            ("date_range_begin", "2023-01-01"),
+            ("date_range_end", "2023-12-31"),
+            ("bandpass_min", 400.0),
+            ("bandpass_max", 700.0),
+            ("bandpass_type", sdk.WavelengthUnit.NM),
+            ("type", sdk.ObservationType.IMAGING),
+            ("depth_value", 20.0),
+            ("depth_unit", sdk.DepthUnit.AB_MAG),
+            ("include_footprints", True),
+        ],
+    )
+    def test_should_be_called_with_inputs(
+        self,
+        mock_observation_api: MagicMock,
+        field: str,
+        value: object,
+    ) -> None:
+        """
+        Verify that `Observation.contains_point()` correctly passes
+        input parameters to the underlying API call.
+
+        Args:
+            mock_observation_api (MagicMock):
+                A mocked instance of `ObservationApi`.
+            field (str):
+                The field name to test.
+            value (object):
+                The value to pass for the field.
+        """
+        observation = Observation(across_client=MagicMock())
+        observation.contains_point(ra=123.45, dec=-65.43, **{field: value})  # type: ignore[arg-type]
+        assert mock_observation_api.contains_point.call_args.kwargs[field] == value


### PR DESCRIPTION
### Description

This PR adds the ability to use the `/observation/contains-point` endpoint with the client. It also fixes a minor typing issue with `bandpass_type` in the `Observation` methods.

### Related Issue(s)

Resolves #60 

### Reviewers

@NASA-ACROSS/developers 

### Acceptance Criteria

1. `/observation/contains-point` requests should be accessible through the client
2. Users should be able to filter these requests on all the optional query params

### Testing

1. Run some queries using `client.observation.contains_point` filtering on different query params while pointing to the prod server and verify the results are correct