### PR TITLE
fix: use env vars as expected, and consistent var naming

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,11 @@
 #### Example .env
 
-HOST=http://localhost:8000/api/v1
+ACROSS_SERVER_HOST="https://api.across.sciencecloud.nasa.gov"
+# Port is really only needed for local development.
+ACROSS_SERVER_PORT=""
+ACROSS_SERVER_ROOT_PATH="/"
+ACROSS_SERVER_VERSION="v1"
 
 # Treedome Automation Service Account Seed in across-server for local testing only
-ACROSS_SERVER_ID=961fbb3b-dd5e-45ff-a282-41033e43933d
-ACROSS_SERVER_SECRET=prehibernationweek
+ACROSS_SERVER_ID="961fbb3b-dd5e-45ff-a282-41033e43933d"
+ACROSS_SERVER_SECRET="prehibernationweek"

--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,8 @@
 #### Example .env
 
-ACROSS_SERVER_HOST="https://api.across.sciencecloud.nasa.gov"
+ACROSS_SERVER_HOST="localhost"
 # Port is really only needed for local development.
-ACROSS_SERVER_PORT=""
+ACROSS_SERVER_PORT="8000"
 ACROSS_SERVER_ROOT_PATH="/"
 ACROSS_SERVER_VERSION="v1"
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # across-client
+
 [![Unit test and smoke test](https://github.com/ACROSS-Team/across-client/actions/workflows/smoke-test.yml/badge.svg)](https://github.com/ACROSS-Team/across-client/actions/workflows/smoke-test.yml)
 <!-- [![Template](https://img.shields.io/badge/Template-LINCC%20Frameworks%20Python%20Project%20Template-brightgreen)](https://lincc-ppt.readthedocs.io/en/latest/)
 
@@ -57,11 +58,13 @@ nircam_observations = client.observation.get_many(
 ### Running the Client in Development
 
 If you are running a development instance of the ACROSS software system, it is straightforward to point your client installation to your local ACROSS `core-server` instance.  
-  1. Follow the server installation instructions [here](https://github.com/NASA-ACROSS/across-server#getting-started). 
-  2.  Copy or duplicate the `.env.example` file in the root directory of this repository and rename it to `.env`. **Important:** This overrides the client's host from the default production server to your local instance by setting a `HOST` variable set to your local server's host and port, which by default is `http://localhost:8000/api/v1`.
+
+  1. Follow the server installation instructions [here](https://github.com/NASA-ACROSS/across-server#getting-started).
+  2. Copy or duplicate the `.env.example` file in the root directory of this repository and rename it to `.env`. **Important:** This overrides the client's host from the default production server to your local instance by setting the `ACROSS_SERVER_HOST` and `ACROSS_SERVER_PORT` variables to the local server's host and port, which by default is host: `http://localhost` and port: `8000`.
   3. Instantiate a new `Client` object, see the example below, and it should now be set up to interface with your local development server!
 
 Using this local setup, you can test submitting schedules to ACROSS. The local server provides a seeded service account with schedule write permissions. Simply instantiate the client using these credentials and you can post a schedule to your local server:
+
 ```py
 from across.client import Client
 
@@ -79,6 +82,7 @@ schedule = client.schedule.get(created_schedule_id)
 
 print(schedule)
 ```
+
 For ease of use, these `ACROSS_SERVER_ID`  and `ACROSS_SERVER_SECRET` variables are part of the `.env.example` file.
 
 ## Contributing
@@ -97,7 +101,7 @@ Science Support (ACROSS) System
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-http://www.apache.org/licenses/LICENSE-2.0
+<http://www.apache.org/licenses/LICENSE-2.0>
 
 Unless required by applicable law or agreed to in writing, software distributed
 under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR

--- a/across/client/client.py
+++ b/across/client/client.py
@@ -39,7 +39,9 @@ class Client:
                 tokens. If provided, it takes precedence over `client_id`
                 and `client_secret`.
         """
-        configuration = sdk.Configuration(host=config.HOST, username=client_id, password=client_secret)
+        configuration = sdk.Configuration(
+            host=config.ACROSS_SERVER_URL, username=client_id, password=client_secret
+        )
         self.across_client = ApiClientWrapper.get_client(configuration=configuration, creds=creds_store)
 
         # configuration.access_token needs to be populated

--- a/across/client/core/config.py
+++ b/across/client/core/config.py
@@ -1,9 +1,12 @@
+from dotenv import load_dotenv
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+load_dotenv()
 
 
 class BaseConfig(BaseSettings):
     """
-    Base configuratiaon for across.client
+    Base configuration for across.client
     """
 
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
@@ -11,12 +14,34 @@ class BaseConfig(BaseSettings):
 
 class Config(BaseConfig):
     """
-    Core configuratiaon for across.client
+    Core configuration for across.client
     """
 
-    HOST: str = "https://api.across.sciencecloud.nasa.gov/v1/"
+    ACROSS_SERVER_HOST: str = "https://api.across.sciencecloud.nasa.gov"
+    ACROSS_SERVER_PORT: str = ""
+    ACROSS_SERVER_ROOT_PATH: str = "/"
+    ACROSS_SERVER_VERSION: str = "v1"
     ACROSS_SERVER_ID: str | None = None
     ACROSS_SERVER_SECRET: str | None = None
+
+    @property
+    def ACROSS_SERVER_URL(self) -> str:  # noqa: D102, N802 uppercase property name is intentional to match env var
+        parts = [
+            self.ACROSS_SERVER_HOST,
+            self.ACROSS_SERVER_ROOT_PATH,
+            self.ACROSS_SERVER_VERSION,
+        ]
+
+        if self.ACROSS_SERVER_PORT:
+            parts.insert(1, f":{self.ACROSS_SERVER_PORT}")
+
+        url = "".join(parts)
+
+        # add protocol if DNE
+        if not url.startswith(("http://", "https://")):
+            url = f"http://{url}"
+
+        return url
 
 
 config = Config()


### PR DESCRIPTION
### Description

use env vars by loading them in with dotenv
makes env var names consistent with frontend/data-ingestion as well

### Related Issue(s)

Resolves #70

### Acceptance Criteria

should load in env vars from .env

### Testing

1. create a new uv project somewhere with `uv init example-app`
2. install the client from this branch `uv add git+https://github.com/NASA-ACROSS/across-client --branch 70-across_server_id-and-across_server_secret-do-not-properly-get-loaded-as-env-vars-with-env`
3. create a `.env` file in that project with

```
# Treedome Automation Service Account Seed in across-server for local testing only
# ACROSS_SERVER_ID=961fbb3b-dd5e-45ff-a282-41033e43933d
# ACROSS_SERVER_SECRET=prehibernationweek

ACROSS_SERVER_HOST=localhost
ACROSS_SERVER_PORT=8000
```

4. copy this `main.py`

```py
from across.client import Client


def main():

    client = Client()

    # observatory
    observatory = client.observatory.get_many(name="jwst")[0]
    observatory = client.observatory.get(id=observatory.id)
    print(observatory.name)
    print(observatory.id)


if __name__ == "__main__":
    main()
```

5. `uv run main.py`
6. should see 
```
(example-app) ❯ uv run main.py
James Webb Space Telescope
fefe0ddc-07af-4312-b3a8-051c4e646619
```
7. uncomment the ACROSS_SERVER_ID and SECRET in the .env, rerun the script, should see unauthorized, which means they are being injected as expected and sent to the prod server which does not have this service account.
```
HTTP response headers: HTTPHeaderDict({'Date': 'Fri, 26 Jun 2026 21:42:33 GMT', 'Content-Type': 'application/json', 'Content-Length': '25', 'Connection': 'keep-alive', 'Set-Cookie': 'AWSALB=AqazcB4tvP2vg2PjrwcYrA29NiEMZ79En9nfiMjYTKPiroxYEhl04MMvM2DsdvYWFeO98O6uF+L7cf9Fc2MJadU6HSYCdeI2wKm6vCgQ3PUL6CqiQj6dF2FUuHMY; Expires=Fri, 03 Jul 2026 21:42:33 GMT; Path=/, AWSALBCORS=AqazcB4tvP2vg2PjrwcYrA29NiEMZ79En9nfiMjYTKPiroxYEhl04MMvM2DsdvYWFeO98O6uF+L7cf9Fc2MJadU6HSYCdeI2wKm6vCgQ3PUL6CqiQj6dF2FUuHMY; Expires=Fri, 03 Jul 2026 21:42:33GMT; Path=/; SameSite=None; Secure', 'server': 'envoy', 'x-request-id': '826076f0-213f-4405-a4f5-9e1c6a087f49', 'x-envoy-upstream-service-time': '20'})
HTTP response body: {"detail":"Unauthorized"}
```