### PR TITLE
feat(observation): add include_footprints argument to GET methods

### DIFF
--- a/across/client/apis/observation.py
+++ b/across/client/apis/observation.py
@@ -22,19 +22,23 @@ class Observation:
         """
         self.across_client = across_client
 
-    def get(self, id: str) -> sdk.Observation:
+    def get(self, id: str, include_footprints: bool | None = None) -> sdk.Observation:
         """
         Retrieve a single Observation by ID.
 
         Args:
             id (str):
                 The unique identifier of the Observation to retrieve.
+            include_footprints (bool | None):
+                Optionally include footprint of the observation.
 
         Returns:
             sdk.Observation:
                 The requested Observation object.
         """
-        return sdk.ObservationApi(self.across_client).get_observation(observation_id=id)
+        return sdk.ObservationApi(self.across_client).get_observation(
+            observation_id=id, include_footprints=include_footprints
+        )
 
     def get_many(
         self,
@@ -59,6 +63,7 @@ class Observation:
         type: sdk.ObservationType | None = None,
         depth_value: float | None = None,
         depth_unit: sdk.DepthUnit | None = None,
+        include_footprints: bool | None = None,
     ) -> sdk.PageObservation:
         """
         Retrieve multiple observations filtered by optional criteria.
@@ -106,6 +111,8 @@ class Observation:
                 Sensitivity or depth threshold value.
             depth_unit (sdk.DepthUnit | None):
                 Unit for `depth_value`.
+            include_footprints (bool | None):
+                Optionally include footprint of the observation.
 
         Returns:
             list[sdk.Observation]:
@@ -133,6 +140,7 @@ class Observation:
             type=type,
             depth_value=depth_value,
             depth_unit=depth_unit,
+            include_footprints=include_footprints,
         )
 
     def contains_point(

--- a/docs/notebooks/001_accessing_SSA_model_data.ipynb
+++ b/docs/notebooks/001_accessing_SSA_model_data.ipynb
@@ -108,7 +108,8 @@
       "Pandora Observatory\n",
       "Euclid Observatory\n",
       "X-ray Imaging and Spectroscopy Mission\n",
-      "Star-Planet Activity Research CubeSat\n"
+      "Star-Planet Activity Research CubeSat\n",
+      "SANDY'S SPACE STATION\n"
      ]
     }
    ],
@@ -456,7 +457,7 @@
      "text": [
       "Page: 1\n",
       "Number of schedules returned: 10\n",
-      "Total number of schedules: 1382\n"
+      "Total number of schedules: 1420\n"
      ]
     }
    ],
@@ -487,21 +488,21 @@
      "output_type": "stream",
      "text": [
       "{\n",
-      "    \"telescope_id\": \"f2ae30ec-cd64-41b1-a951-4da29aa9f4ab\",\n",
-      "    \"name\": \"XMM_Newton_planned_2026-06-18_2026-07-18\",\n",
+      "    \"telescope_id\": \"87e15f42-72c0-4973-a1f6-c23807cf90c5\",\n",
+      "    \"name\": \"Bikini Bottom Schedule\",\n",
       "    \"date_range\": {\n",
-      "        \"begin\": \"2026-06-18T12:09:37\",\n",
-      "        \"end\": \"2026-07-18T02:29:08\"\n",
+      "        \"begin\": \"2026-07-10T11:53:52.342119\",\n",
+      "        \"end\": \"2026-07-11T11:53:52.342122\"\n",
       "    },\n",
       "    \"status\": \"planned\",\n",
-      "    \"external_id\": null,\n",
+      "    \"external_id\": \"BikiniBottom_schedule_id_1234\",\n",
       "    \"fidelity\": \"low\",\n",
-      "    \"id\": \"189758df-a9c9-4ce5-9800-d6a63f9d2d76\",\n",
+      "    \"id\": \"3f8a9900-158d-4227-b689-546a37e458ba\",\n",
       "    \"observations\": [],\n",
-      "    \"observation_count\": 464,\n",
-      "    \"created_on\": \"2026-06-18T09:00:15.025364\",\n",
-      "    \"created_by_id\": \"1022155f-f13d-4ade-ac73-3d1941f612da\",\n",
-      "    \"checksum\": \"4e42ea60830b0964b6d680e43388a226c850cde4d7a77e41c78a732aa63199d3422d9f6f7d9dc2d19951f36cd171844b6f30174f6d7fac9f936dce28ba45c9b2\"\n",
+      "    \"observation_count\": 1,\n",
+      "    \"created_on\": \"2026-07-10T15:53:52.720143\",\n",
+      "    \"created_by_id\": \"e2c834a4-232c-420a-985e-eb5bc59aba24\",\n",
+      "    \"checksum\": \"fec1a041044a922cff136b27a0a95c634b177dfb623a00e8b639baecef680bf911bb27727d0b5ed9ff3abafb36c10f74f45a3bdf4f9ad2f9837e63755f9d6623\"\n",
       "}\n"
      ]
     }
@@ -526,29 +527,29 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Number of observations: 464\n",
+      "Number of observations: 1\n",
       "{\n",
-      "    \"instrument_id\": \"ab55be45-9796-40da-8125-e512f446ac96\",\n",
-      "    \"object_name\": \"CC Eri\",\n",
+      "    \"instrument_id\": \"a4cf7691-8d3c-4fea-899c-9bcc33d23a5e\",\n",
+      "    \"object_name\": \"Krusty Krab\",\n",
       "    \"pointing_position\": {\n",
-      "        \"ra\": 38.59167,\n",
-      "        \"dec\": -43.79833\n",
+      "        \"ra\": 123.456,\n",
+      "        \"dec\": -78.901\n",
       "    },\n",
       "    \"date_range\": {\n",
-      "        \"begin\": \"2026-07-17T12:42:28\",\n",
-      "        \"end\": \"2026-07-18T02:10:48\"\n",
+      "        \"begin\": \"2026-07-10T11:53:52.342179\",\n",
+      "        \"end\": \"2026-07-11T11:53:52.342180\"\n",
       "    },\n",
-      "    \"external_observation_id\": \"0982970101\",\n",
+      "    \"external_observation_id\": \"Sandy's Treedome Observations\",\n",
       "    \"type\": \"imaging\",\n",
       "    \"status\": \"planned\",\n",
-      "    \"pointing_angle\": 64.58,\n",
-      "    \"exposure_time\": 48500.0,\n",
+      "    \"pointing_angle\": null,\n",
+      "    \"exposure_time\": null,\n",
       "    \"reason\": null,\n",
       "    \"description\": null,\n",
       "    \"proposal_reference\": null,\n",
       "    \"object_position\": {\n",
-      "        \"ra\": 38.59167,\n",
-      "        \"dec\": -43.79833\n",
+      "        \"ra\": 123.567,\n",
+      "        \"dec\": -78.876\n",
       "    },\n",
       "    \"depth\": null,\n",
       "    \"bandpass\": {\n",
@@ -556,19 +557,19 @@
       "        \"anyof_schema_2_validator\": null,\n",
       "        \"anyof_schema_3_validator\": null,\n",
       "        \"actual_instance\": {\n",
-      "            \"filter_name\": \"XMM-Newton EPIC\",\n",
-      "            \"min\": 1.0332016536100035,\n",
-      "            \"max\": 41.32806614440008,\n",
+      "            \"filter_name\": null,\n",
+      "            \"min\": 4500.0,\n",
+      "            \"max\": 6500.0,\n",
       "            \"type\": \"WAVELENGTH\",\n",
-      "            \"central_wavelength\": 21.18063389900504,\n",
+      "            \"central_wavelength\": 5500.0,\n",
       "            \"peak_wavelength\": null,\n",
-      "            \"bandwidth\": 20.147432245395038,\n",
+      "            \"bandwidth\": 1000.0,\n",
       "            \"unit\": \"angstrom\"\n",
       "        },\n",
       "        \"any_of_schemas\": [\n",
-      "            \"WavelengthBandpass\",\n",
+      "            \"EnergyBandpass\",\n",
       "            \"FrequencyBandpass\",\n",
-      "            \"EnergyBandpass\"\n",
+      "            \"WavelengthBandpass\"\n",
       "        ]\n",
       "    },\n",
       "    \"t_resolution\": null,\n",
@@ -579,9 +580,9 @@
       "    \"category\": null,\n",
       "    \"priority\": null,\n",
       "    \"tracking_type\": null,\n",
-      "    \"id\": \"543e0706-532d-4b9b-9245-a22ce3996a39\",\n",
-      "    \"schedule_id\": \"189758df-a9c9-4ce5-9800-d6a63f9d2d76\",\n",
-      "    \"created_on\": \"2026-06-18T09:00:15.075349\",\n",
+      "    \"id\": \"9ec854d3-6746-4282-94e7-c96d53251dda\",\n",
+      "    \"schedule_id\": \"3f8a9900-158d-4227-b689-546a37e458ba\",\n",
+      "    \"created_on\": \"2026-07-10T15:53:52.728547\",\n",
       "    \"created_by_id\": null,\n",
       "    \"footprint\": []\n",
       "}\n"
@@ -613,7 +614,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Number of recent schedules: 1414\n"
+      "Number of recent schedules: 1452\n"
      ]
     }
    ],
@@ -639,7 +640,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Number of observations: 464\n"
+      "Number of observations: 1\n"
      ]
     }
    ],
@@ -666,21 +667,21 @@
      "output_type": "stream",
      "text": [
       "{\n",
-      "    \"telescope_id\": \"f2ae30ec-cd64-41b1-a951-4da29aa9f4ab\",\n",
-      "    \"name\": \"XMM_Newton_planned_2026-06-18_2026-07-18\",\n",
+      "    \"telescope_id\": \"87e15f42-72c0-4973-a1f6-c23807cf90c5\",\n",
+      "    \"name\": \"Bikini Bottom Schedule\",\n",
       "    \"date_range\": {\n",
-      "        \"begin\": \"2026-06-18T12:09:37\",\n",
-      "        \"end\": \"2026-07-18T02:29:08\"\n",
+      "        \"begin\": \"2026-07-10T11:53:52.342119\",\n",
+      "        \"end\": \"2026-07-11T11:53:52.342122\"\n",
       "    },\n",
       "    \"status\": \"planned\",\n",
-      "    \"external_id\": null,\n",
+      "    \"external_id\": \"BikiniBottom_schedule_id_1234\",\n",
       "    \"fidelity\": \"low\",\n",
-      "    \"id\": \"189758df-a9c9-4ce5-9800-d6a63f9d2d76\",\n",
+      "    \"id\": \"3f8a9900-158d-4227-b689-546a37e458ba\",\n",
       "    \"observations\": [],\n",
-      "    \"observation_count\": 464,\n",
-      "    \"created_on\": \"2026-06-18T09:00:15.025364\",\n",
-      "    \"created_by_id\": \"1022155f-f13d-4ade-ac73-3d1941f612da\",\n",
-      "    \"checksum\": \"4e42ea60830b0964b6d680e43388a226c850cde4d7a77e41c78a732aa63199d3422d9f6f7d9dc2d19951f36cd171844b6f30174f6d7fac9f936dce28ba45c9b2\"\n",
+      "    \"observation_count\": 1,\n",
+      "    \"created_on\": \"2026-07-10T15:53:52.720143\",\n",
+      "    \"created_by_id\": \"e2c834a4-232c-420a-985e-eb5bc59aba24\",\n",
+      "    \"checksum\": \"fec1a041044a922cff136b27a0a95c634b177dfb623a00e8b639baecef680bf911bb27727d0b5ed9ff3abafb36c10f74f45a3bdf4f9ad2f9837e63755f9d6623\"\n",
       "}\n"
      ]
     }
@@ -714,27 +715,27 @@
      "output_type": "stream",
      "text": [
       "{\n",
-      "    \"instrument_id\": \"77cd205f-9062-4a66-8a9e-19eb77f831c1\",\n",
-      "    \"object_name\": \"TESS_sector_97_obs_5_orbit_203\",\n",
+      "    \"instrument_id\": \"a4cf7691-8d3c-4fea-899c-9bcc33d23a5e\",\n",
+      "    \"object_name\": \"Krusty Krab\",\n",
       "    \"pointing_position\": {\n",
-      "        \"ra\": 41.6581,\n",
-      "        \"dec\": -41.8452\n",
+      "        \"ra\": 123.456,\n",
+      "        \"dec\": -78.901\n",
       "    },\n",
       "    \"date_range\": {\n",
-      "        \"begin\": \"2025-10-19T03:45:00\",\n",
-      "        \"end\": \"2025-10-26T06:15:00\"\n",
+      "        \"begin\": \"2026-07-10T11:53:52.342179\",\n",
+      "        \"end\": \"2026-07-11T11:53:52.342180\"\n",
       "    },\n",
-      "    \"external_observation_id\": \"TESS_sector_97_obs_5_orbit_203\",\n",
+      "    \"external_observation_id\": \"Sandy's Treedome Observations\",\n",
       "    \"type\": \"imaging\",\n",
       "    \"status\": \"planned\",\n",
-      "    \"pointing_angle\": 210.3682,\n",
-      "    \"exposure_time\": 613800.0,\n",
+      "    \"pointing_angle\": null,\n",
+      "    \"exposure_time\": null,\n",
       "    \"reason\": null,\n",
       "    \"description\": null,\n",
       "    \"proposal_reference\": null,\n",
       "    \"object_position\": {\n",
-      "        \"ra\": null,\n",
-      "        \"dec\": null\n",
+      "        \"ra\": 123.567,\n",
+      "        \"dec\": -78.876\n",
       "    },\n",
       "    \"depth\": null,\n",
       "    \"bandpass\": {\n",
@@ -742,19 +743,19 @@
       "        \"anyof_schema_2_validator\": null,\n",
       "        \"anyof_schema_3_validator\": null,\n",
       "        \"actual_instance\": {\n",
-      "            \"filter_name\": \"TESS_red\",\n",
-      "            \"min\": 6000.0,\n",
-      "            \"max\": 10000.0,\n",
+      "            \"filter_name\": null,\n",
+      "            \"min\": 4500.0,\n",
+      "            \"max\": 6500.0,\n",
       "            \"type\": \"WAVELENGTH\",\n",
-      "            \"central_wavelength\": 8000.0,\n",
-      "            \"peak_wavelength\": 7865.0,\n",
-      "            \"bandwidth\": 2000.0,\n",
+      "            \"central_wavelength\": 5500.0,\n",
+      "            \"peak_wavelength\": null,\n",
+      "            \"bandwidth\": 1000.0,\n",
       "            \"unit\": \"angstrom\"\n",
       "        },\n",
       "        \"any_of_schemas\": [\n",
-      "            \"WavelengthBandpass\",\n",
+      "            \"EnergyBandpass\",\n",
       "            \"FrequencyBandpass\",\n",
-      "            \"EnergyBandpass\"\n",
+      "            \"WavelengthBandpass\"\n",
       "        ]\n",
       "    },\n",
       "    \"t_resolution\": null,\n",
@@ -765,9 +766,9 @@
       "    \"category\": null,\n",
       "    \"priority\": null,\n",
       "    \"tracking_type\": null,\n",
-      "    \"id\": \"3f486da9-6741-43ac-aca4-c52af5dda3b7\",\n",
-      "    \"schedule_id\": \"184d8820-bea5-4ad3-aec0-4e98999aabba\",\n",
-      "    \"created_on\": \"2026-05-20T05:12:29.939891\",\n",
+      "    \"id\": \"9ec854d3-6746-4282-94e7-c96d53251dda\",\n",
+      "    \"schedule_id\": \"3f8a9900-158d-4227-b689-546a37e458ba\",\n",
+      "    \"created_on\": \"2026-07-10T15:53:52.728547\",\n",
       "    \"created_by_id\": null,\n",
       "    \"footprint\": []\n",
       "}\n"
@@ -779,7 +780,9 @@
     "from datetime import datetime\n",
     "\n",
     "observations = client.observation.get_many(\n",
-    "    page=1, page_limit=10, date_range_begin=datetime(2025, 10, 20), date_range_end=datetime(2025, 10, 21)\n",
+    "    page=1,\n",
+    "    page_limit=10,\n",
+    "    date_range_begin=datetime(2025, 10, 20),\n",
     ")\n",
     "print(observations.items[0].model_dump_json(indent=4))"
    ]
@@ -812,7 +815,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Number of observations returned: 25173\n",
+      "Number of observations returned: 25732\n",
       "The same process can be used to get observations by telescope, instrument, and schedule ID\n"
      ]
     }
@@ -834,7 +837,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Number of observations returned: 18352\n"
+      "Number of observations returned: 19019\n"
      ]
     }
    ],
@@ -853,7 +856,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Number of observations returned: 843523\n"
+      "Number of observations returned: 864224\n"
      ]
     }
    ],
@@ -861,13 +864,6 @@
     "# GET observations by status\n",
     "observations = client.observation.get_many(page=1, page_limit=10, status=\"planned\")\n",
     "print(f\"Number of observations returned: {observations.model_dump()['total_number']}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "A user can also retrieve `Observations` that contain a point on the sky:"
    ]
   },
   {
@@ -879,7 +875,40 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Number of observations returned: 2915\n"
+      "Projected observation footprint: [{'polygon': [{'x': 125.94121, 'y': -78.39036}, {'x': 126.1723, 'y': -79.38937}, {'x': 120.7397, 'y': -79.38937}, {'x': 120.97079, 'y': -78.39036}, {'x': 125.94121, 'y': -78.39036}], 'id': '0f97afdc-b3bb-4974-9a8a-0a51785d9dc5', 'observation_id': '9ec854d3-6746-4282-94e7-c96d53251dda'}]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Include the instrument footprint projected at the pointing position of the observation\n",
+    "observations = client.observation.get_many(\n",
+    "    page=1,\n",
+    "    page_limit=10,\n",
+    "    bandpass_min=4000.0,\n",
+    "    bandpass_max=7000.0,\n",
+    "    bandpass_type=\"angstrom\",\n",
+    "    include_footprints=True,\n",
+    ")\n",
+    "print(f\"Projected observation footprint: {observations.items[0].model_dump()['footprint']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A user can also retrieve `Observations` that contain a point on the sky:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of observations returned: 210115\n"
      ]
     }
    ],
@@ -894,14 +923,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Number of observations returned: 0\n"
+      "Number of observations returned: 2\n"
      ]
     }
    ],

--- a/docs/schedules.rst
+++ b/docs/schedules.rst
@@ -519,6 +519,9 @@ These are shown below:
    * - ``depth_unit``
      - str | None
      - Unit for the depth of the ``Observation`` (one of ``ab_mag``, ``vega_mag``, ``flux_erg``, or ``flux_jy``)
+   * - ``include_footprints``
+     - bool | None
+     - Optionally include projected footprints for each observation
 
 
 The ``client.observation.contains_point()`` method takes a similar list of optional parameters.
@@ -648,6 +651,9 @@ Below are some of the more relevant attributes of an ``Observation`` object:
    * - ``created_by_id``
      - str | None
      - ID of user that created the schedule in the ACROSS ``core-server``
+   * - ``footprint``
+     - list[ObservationFootprint] | None
+     - The footprint of the observation, represented as a list of polygon coordinates projected to the pointing position of the observation
 
 IVOA compliance
 ^^^^^^^^^^^^^^^

--- a/tests/apis/observation/test_observation.py
+++ b/tests/apis/observation/test_observation.py
@@ -41,7 +41,21 @@ class TestGet:
         id = str(uuid4())
         observation = Observation(across_client=MagicMock())
         observation.get(id)
-        mock_observation_api.get_observation.assert_called_once_with(observation_id=id)
+        assert mock_observation_api.get_observation.call_args.kwargs["observation_id"] == id
+
+    def test_should_pass_include_footprints_to_api(self, mock_observation_api: MagicMock) -> None:
+        """
+        Verify that `Observation.get()` passes the optional `include_footprints`
+        argument to the `ObservationApi.get_observation()` method call.
+
+        Args:
+            mock_observation_api (MagicMock):
+                A mocked instance of `ObservationApi`.
+        """
+        id = str(uuid4())
+        observation = Observation(across_client=MagicMock())
+        observation.get(id, include_footprints=True)
+        assert mock_observation_api.get_observation.call_args.kwargs["include_footprints"] is True
 
 
 class TestGetMany:
@@ -60,6 +74,19 @@ class TestGetMany:
         observation = Observation(across_client=MagicMock())
         result = observation.get_many()
         assert result == fake_page_observation
+
+    def test_should_pass_include_footprints_to_api(self, mock_observation_api: MagicMock) -> None:
+        """
+        Verify that `Observation.get_many()` passes the optional `include_footprints`
+        argument to the `ObservationApi.get_observations()` method call.
+
+        Args:
+            mock_observation_api (MagicMock):
+                A mocked instance of `ObservationApi`.
+        """
+        observation = Observation(across_client=MagicMock())
+        observation.get_many(include_footprints=True)
+        assert mock_observation_api.get_observations.call_args.kwargs["include_footprints"] is True
 
 
 class TestContainsPoint:


### PR DESCRIPTION
### Description

This PR adds missing optional `include_footprints` parameters to the `Client` `Observation.get()` and `Observation.get_many()` methods. It also updates tests and documentation to reflect this addition.

### Related Issue(s)

Resolves #66 

### Acceptance Criteria

1. Should include observation footprints in return object if `include_footprints` is `True`

### Testing

1. Open a shell and instantiate your client
2. Try some example `client.observation.get()` and `client.observation.get_many()` calls with `include_footprints=True` and verify you get footprint data back
3. Make sure updates to the docs and example notebook look good